### PR TITLE
Update version to 1.5-SNAPSHOT, skip 1.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ val defaultVersions = Map("firrtl" -> "1.5-SNAPSHOT")
 lazy val baseSettings = Seq(
   name := "treadle",
   organization := "edu.berkeley.cs",
-  version := "1.4-SNAPSHOT",
+  version := "1.5-SNAPSHOT",
   scalaVersion := "2.12.10",
   crossScalaVersions := Seq("2.12.10", "2.11.12"),
   // enables using control-c in sbt CLI

--- a/build.sc
+++ b/build.sc
@@ -35,7 +35,7 @@ trait CommonModule extends ScalaModule with SbtModule with PublishModule {
 
   def ivyDeps = super.ivyDeps() ++ firrtlIvyDeps
 
-  def publishVersion = "1.4-SNAPSHOT"
+  def publishVersion = "1.5-SNAPSHOT"
 
   // 2.12.11 -> Array("2", "12", "10") -> "12" -> 12
   protected def majorVersion = crossVersion.split('.')(1).toInt


### PR DESCRIPTION
This brings the major version of Treadle in line with Chisel and FIRRTL.