### PR TITLE
Automatically publish SNAPSHOTs on pushes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,12 @@
 name: Test
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - 1.3.x
+      - 1.2.x
 
 jobs:
   test:
@@ -19,3 +25,19 @@ jobs:
       - name: Test
         id: test
         run: sbt +test
+      # Publishing steps
+      # These steps are here to avoid duplicated work and logic
+      - name: Setup GPG (for Publish)
+        id: publish_start
+        # on.push.branches above enforces we only publish from correct branches
+        if: github.event_name == 'push'
+        uses: olafurpg/setup-gpg@v3
+      - name: Publish
+        # publish_start if guards this step
+        if: steps.publish_start.outcome != 'skipped'
+        run: sbt ci-release
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,3 +2,5 @@ logLevel := Level.Warn
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
+
+addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.4")


### PR DESCRIPTION
Uses sbt-ci-release for automation

Counterpart of https://github.com/chipsalliance/firrtl/pull/1955

~~**FIXME** For validation, this should push to 1.5-SNAPSHOT. Will make the release flow only happen on pushes before merging.~~ Things work correctly!