### PR TITLE
Fix milestone in .mergify.yml

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -32,7 +32,7 @@ pull_request_rules:
     conditions:
       - merged
       - base=master
-      - milestone=1.2.X
+      - milestone=1.2.x
     actions:
       backport:
         branches:


### PR DESCRIPTION
This was probably copied from FIRRTL, but the actual milestone is `1.2.x`, not `1.2.X`