### PR TITLE
Remove explicit pom scm from build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -89,10 +89,6 @@ lazy val publishSettings = Seq(
       <distribution>repo</distribution>
     </license>
   </licenses>
-  <scm>
-    <url>https://github.com/freechipsproject/treadle.git</url>
-    <connection>scm:git:github.com/freechipsproject/treadle.git</connection>
-  </scm>
   <developers>
     <developer>
       <id>chick</id>


### PR DESCRIPTION
This is now set by sbt-ci-release