### PR TITLE
Add support for Scala 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,17 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-def scalacOptionsVersion(scalaVersion: String): Seq[String] = {
-  Seq() ++ {
-    // If we're building with Scala > 2.11, enable the compile option
-    //  switch to support our anonymous Bundle definitions:
-    //  https://github.com/scala/bug/issues/10047
-    CrossVersion.partialVersion(scalaVersion) match {
-      case Some((2, scalaMajor: Long)) if scalaMajor < 12 => Seq()
-      case _ => Seq("-Xsource:2.11")
-    }
-  }
-}
-
 def javacOptionsVersion(scalaVersion: String): Seq[String] = {
   Seq() ++ {
     // Scala 2.12 requires Java 8. We continue to generate
@@ -33,8 +21,8 @@ lazy val baseSettings = Seq(
   name := "treadle",
   organization := "edu.berkeley.cs",
   version := "1.5-SNAPSHOT",
-  scalaVersion := "2.12.10",
-  crossScalaVersions := Seq("2.12.10", "2.11.12"),
+  scalaVersion := "2.13.4",
+  crossScalaVersions := Seq("2.13.4", "2.12.10", "2.11.12"),
   // enables using control-c in sbt CLI
   cancelable in Global := true,
   resolvers ++= Seq(
@@ -64,8 +52,7 @@ lazy val baseSettings = Seq(
     "-unchecked",
     "-language:reflectiveCalls",
     "-language:existentials",
-    "-language:implicitConversions",
-    "-Ywarn-unused-import" // required by `RemoveUnused` rule
+    "-language:implicitConversions"
   ),
   javacOptions ++= javacOptionsVersion(scalaVersion.value)
 )
@@ -122,7 +109,7 @@ lazy val docSettings = Seq(
     "-sourcepath",
     baseDirectory.value.getAbsolutePath,
     "-unchecked"
-  ) ++ scalacOptionsVersion(scalaVersion.value)
+  )
 )
 
 lazy val treadle = (project in file("."))

--- a/build.sc
+++ b/build.sc
@@ -8,7 +8,7 @@ import coursier.maven.MavenRepository
 import $ivy.`com.lihaoyi::mill-contrib-buildinfo:$MILL_VERSION`
 import mill.contrib.buildinfo.BuildInfo
 
-object treadle extends mill.Cross[treadleCrossModule]("2.11.12", "2.12.11")
+object treadle extends mill.Cross[treadleCrossModule]("2.11.12", "2.12.12", "2.13.4")
 
 // The following stanza is searched for and used when preparing releases.
 // Please retain it.
@@ -49,11 +49,6 @@ trait CommonModule extends ScalaModule with SbtModule with PublishModule {
     MavenRepository("https://oss.sonatype.org/content/repositories/releases")
   )
 
-  private def scalacCrossOptions = majorVersion match {
-    case i if i < 12 => Seq()
-    case _           => Seq("-Xsource:2.11")
-  }
-
   private def javacCrossOptions = majorVersion match {
     case i if i < 12 => Seq("-source", "1.7", "-target", "1.7")
     case _           => Seq("-source", "1.8", "-target", "1.8")
@@ -62,15 +57,9 @@ trait CommonModule extends ScalaModule with SbtModule with PublishModule {
   override def scalacOptions = super.scalacOptions() ++ Agg(
     "-deprecation",
     "-feature"
-  ) ++ scalacCrossOptions
+  )
 
   override def javacOptions = super.javacOptions() ++ javacCrossOptions
-
-  private val macroParadise = ivy"org.scalamacros:::paradise:2.1.1"
-
-  override def compileIvyDeps = Agg(macroParadise)
-
-  override def scalacPluginIvyDeps = Agg(macroParadise)
 
   def pomSettings = PomSettings(
     description = artifactName(),

--- a/src/main/scala/treadle/Regression.scala
+++ b/src/main/scala/treadle/Regression.scala
@@ -24,7 +24,7 @@ object Regression {
   }
 
   //scalastyle:off method.length
-  def manyValuesTest(width: Int) {
+  def manyValuesTest(width: Int): Unit = {
     val gcdFirrtl: String =
       s"""
          |circuit GCD :

--- a/src/main/scala/treadle/ScalaBlackBox.scala
+++ b/src/main/scala/treadle/ScalaBlackBox.scala
@@ -6,7 +6,7 @@ import firrtl.ir.{Param, Type}
 import treadle.blackboxes.PlusArg
 import treadle.executable.Transition
 
-import scala.collection._
+import scala.collection.mutable
 
 /**
   * This is the template for writing Scala functions that implement the behaviour of a

--- a/src/main/scala/treadle/TreadleRepl.scala
+++ b/src/main/scala/treadle/TreadleRepl.scala
@@ -977,7 +977,7 @@ class TreadleRepl(initialAnnotations: AnnotationSeq) {
           }
         }
 
-        def showRelated(direction: String, digraph: DiGraph[Symbol], symbolName: String, maxDepth: Int) {
+        def showRelated(direction: String, digraph: DiGraph[Symbol], symbolName: String, maxDepth: Int): Unit = {
           val table = engine.symbolTable
           val symbol = engine.symbolTable(symbolName)
           val symbolsAtDepth = Array.fill(maxDepth + 1) {
@@ -1020,7 +1020,7 @@ class TreadleRepl(initialAnnotations: AnnotationSeq) {
               console.println(s"""You must specify a symbol with command "depend childrenOf" """)
             case Some("compare") :: Some(symbolName1) :: Some(symbolName2) :: _ =>
               val (symbol1, symbol2) = (table(symbolName1), table(symbolName2))
-              def showPath(direction: String, digraph: DiGraph[Symbol]) {
+              def showPath(direction: String, digraph: DiGraph[Symbol]): Unit = {
                 try {
                   val path = digraph.path(symbol1, symbol2)
                   console.println(s"$symbol1 is a $direction of $symbol2 via")

--- a/src/main/scala/treadle/blackboxes/EicgWrapper.scala
+++ b/src/main/scala/treadle/blackboxes/EicgWrapper.scala
@@ -53,7 +53,7 @@ class EicgWrapper(val instanceName: String) extends ScalaBlackBox {
     Seq.empty
   }
 
-  override def getDependencies: Seq[(String, collection.Set[String])] = {
+  override def getDependencies: Seq[(String, Set[String])] = {
     //TODO: This is the current form, but errors reported from users still using 8 month old
 //    Seq("out" -> Set("in", "en", "test_en"))
     Seq("out" -> Set("in", "en"))

--- a/src/main/scala/treadle/blackboxes/PlusArgReader.scala
+++ b/src/main/scala/treadle/blackboxes/PlusArgReader.scala
@@ -75,7 +75,7 @@ class PlusArgReader(val instanceName: String) extends ScalaBlackBox {
     Seq.empty
   }
 
-  override def getDependencies: Seq[(String, collection.Set[String])] = {
+  override def getDependencies: Seq[(String, Set[String])] = {
     Seq.empty
   }
 }

--- a/src/main/scala/treadle/coverage/package.scala
+++ b/src/main/scala/treadle/coverage/package.scala
@@ -103,7 +103,7 @@ package object coverage {
     /**
       * Retrieves a sequence containing all of the coverage ports
       */
-    def ports: Seq[Port] = coveragePorts
+    def ports: Seq[Port] = coveragePorts.toSeq
 
     /**
       * Creates and recors a new coverage validation port

--- a/src/main/scala/treadle/coverage/pass/AddCoverageExpressions.scala
+++ b/src/main/scala/treadle/coverage/pass/AddCoverageExpressions.scala
@@ -84,13 +84,15 @@ object AddCoverageExpressions extends Pass {
     * Traverse statements, find muxes and insert coverage expressions there
     */
   private def coverS(ledger: Ledger, namespace: Namespace)(s: Statement): Statement = {
-    val block = mutable.ArrayBuffer[Statement]()
     s match {
       case s: HasInfo =>
+        val block = mutable.ArrayBuffer[Statement]()
         val newStmt = s.mapExpr(coverE(ledger, namespace, block))
         block.length match {
           case 0 => newStmt
-          case _ => Block(block :+ newStmt)
+          case _ =>
+            block += newStmt
+            Block(block.toSeq)
         }
       case s => s.mapStmt(coverS(ledger, namespace))
     }

--- a/src/main/scala/treadle/executable/BlackBoxCycler.scala
+++ b/src/main/scala/treadle/executable/BlackBoxCycler.scala
@@ -27,6 +27,6 @@ case class BlackBoxCycler(
     if (isVerbose) {
       println(s"${symbol.name} : clock ${clockSymbol.name} state ($transition)")
     }
-    () => Unit
+    () => ()
   }
 }

--- a/src/main/scala/treadle/executable/DataStore.scala
+++ b/src/main/scala/treadle/executable/DataStore.scala
@@ -190,7 +190,7 @@ class DataStore(val numberOfBuffers: Int, dataStoreAllocator: DataStoreAllocator
     override def run: FuncUnit = {
       underlyingAssigner.run()
       blackBox.inputChanged(portName, apply(symbol))
-      () => Unit
+      () => ()
     }
   }
 

--- a/src/main/scala/treadle/executable/DataStore.scala
+++ b/src/main/scala/treadle/executable/DataStore.scala
@@ -473,15 +473,15 @@ class DataStore(val numberOfBuffers: Int, dataStoreAllocator: DataStoreAllocator
     }.toMap
 
     def toIntJArray(array: Array[Int]) =
-      JArray(array.toList.map { a ⇒
+      JArray(array.toList.map { a =>
         val v: JValue = a; v
       })
     def toLongJArray(array: Array[Long]) =
-      JArray(array.toList.map { a ⇒
+      JArray(array.toList.map { a =>
         val v: JValue = a; v
       })
     def toBigJArray(array: Array[Big]) =
-      JArray(array.toList.map { a ⇒
+      JArray(array.toList.map { a =>
         val v: JValue = a; v
       })
 

--- a/src/main/scala/treadle/executable/ExpressionCompiler.scala
+++ b/src/main/scala/treadle/executable/ExpressionCompiler.scala
@@ -767,7 +767,7 @@ class ExpressionCompiler(
                     val inputSymbols = implementation.outputDependencies(port.name).map { inputName =>
                       symbolTable(expand(instanceName + "." + inputName))
                     }
-                    val shim = dataStore.BlackBoxShim(port.name, portSymbol, inputSymbols, implementation)
+                    val shim = dataStore.BlackBoxShim(port.name, portSymbol, inputSymbols.toSeq, implementation)
                     makeAssigner(portSymbol, shim, info = info)
                   }
                   if (port.tpe == ClockType) {

--- a/src/main/scala/treadle/executable/PrintfOp.scala
+++ b/src/main/scala/treadle/executable/PrintfOp.scala
@@ -35,7 +35,7 @@ case class PrintfOp(
       print(instantiatedString)
     }
 
-    () => Unit
+    () => ()
   }
 
   def asIs(b:       BigInt): BigInt = b
@@ -107,7 +107,7 @@ case class PrintfOp(
           }
       }
     }
-    (StringContext.treatEscapes(outBuffer.toString()), filters)
+    (StringContext.treatEscapes(outBuffer.toString()), filters.toSeq)
   }
 
   def executeVerilogPrint(allArgs: Seq[BigInt]): String = {

--- a/src/main/scala/treadle/executable/Scheduler.scala
+++ b/src/main/scala/treadle/executable/Scheduler.scala
@@ -128,21 +128,24 @@ class Scheduler(val symbolTable: SymbolTable) extends LazyLogging {
     *  updates signals that depend on inputs
     */
   def executeCombinationalAssigns(): Unit = {
-    executeAssigners(combinationalAssigns)
+    executeAssigners(combinationalAssigns.toSeq)
   }
 
   /**
     *  updates signals that depend on inputs
     */
   def executeOrphanedAssigns(): Unit = {
-    executeAssigners(orphanedAssigns)
+    executeAssigners(orphanedAssigns.toSeq)
   }
 
   /**
     * de-duplicates and sorts assignments that depend on top level inputs.
     */
   def sortInputSensitiveAssigns(): Unit = {
-    val deduplicatedAssigns = (combinationalAssigns -- orphanedAssigns).distinct
+    val buf = mutable.ArrayBuffer[Assigner]()
+    buf ++= combinationalAssigns
+    buf --= orphanedAssigns
+    val deduplicatedAssigns = buf.distinct
     combinationalAssigns = deduplicatedAssigns.sortBy { assigner: Assigner =>
       assigner.symbol.cardinalNumber
     } ++ endOfCycleAssigns

--- a/src/main/scala/treadle/executable/StopOp.scala
+++ b/src/main/scala/treadle/executable/StopOp.scala
@@ -29,7 +29,7 @@ case class StopOp(
       }
     }
 
-    () => Unit
+    () => ()
   }
 }
 

--- a/src/main/scala/treadle/executable/SymbolTable.scala
+++ b/src/main/scala/treadle/executable/SymbolTable.scala
@@ -210,12 +210,7 @@ object SymbolTable extends LazyLogging {
     var printfCardinal: Int = 0
     val lastPrintfInMOdule = new mutable.HashMap[Module, Symbol]
 
-    val moduleMemoryToMemorySymbol = new mutable.HashMap[String, mutable.HashSet[Symbol]] {
-      override def default(key: String): mutable.HashSet[Symbol] = {
-        this(key) = new mutable.HashSet[Symbol]()
-        this(key)
-      }
-    }
+    val moduleMemoryToMemorySymbol = new mutable.HashMap[String, mutable.HashSet[Symbol]]()
 
     val blackBoxImplementations = new mutable.HashMap[Symbol, ScalaBlackBox]()
 
@@ -404,7 +399,8 @@ object SymbolTable extends LazyLogging {
           }
           val moduleMemory = module.name + "." + defMemory.name
 
-          moduleMemoryToMemorySymbol(moduleMemory) += memorySymbols.head
+          val values = moduleMemoryToMemorySymbol.getOrElseUpdate(moduleMemory, new mutable.HashSet)
+          values += memorySymbols.head
 
         case stop @ Stop(info, _, clockExpression, enableExpression) =>
           getClockSymbol(clockExpression) match {

--- a/src/main/scala/treadle/utils/AugmentPrintf.scala
+++ b/src/main/scala/treadle/utils/AugmentPrintf.scala
@@ -41,7 +41,8 @@ class AugmentPrintf extends Transform with DependencyAPIMigration {
         case s: Stop =>
           val newStmts = mutable.ArrayBuffer[Statement]()
           val newStop = s.mapExpr(insert(newStmts, namespace, s.info, s.clk))
-          Block(newStmts :+ newStop)
+          newStmts += newStop
+          Block(newStmts.toSeq)
         case p: Print =>
           val newStmts = mutable.ArrayBuffer[Statement]()
           val newName = namespace.newTemp
@@ -51,7 +52,8 @@ class AugmentPrintf extends Transform with DependencyAPIMigration {
 
           val newPrint: Print =
             p.mapExpr(insert(newStmts, namespace, p.info, p.clk)).asInstanceOf[Print].copy(en = wref)
-          Block(newStmts :+ newPrint)
+          newStmts += newPrint
+          Block(newStmts.toSeq)
         case other => other
       }
 

--- a/src/main/scala/treadle/utils/NameBasedRandomNumberGenerator.scala
+++ b/src/main/scala/treadle/utils/NameBasedRandomNumberGenerator.scala
@@ -19,7 +19,7 @@ class NameBasedRandomNumberGenerator {
     rand.setSeed(name.hashCode + deviationSeed)
     rand.setSeed(rand.nextLong())
     rand.setSeed(rand.nextLong())
-    rand.nextLong
+    rand.nextLong()
     BigInt(bitWidth, rand)
   }
 }

--- a/src/main/scala/treadle/vcd/diff/VcdComparator.scala
+++ b/src/main/scala/treadle/vcd/diff/VcdComparator.scala
@@ -262,7 +262,7 @@ class VcdComparator(annotationSeq: AnnotationSeq) {
     if (doUnmatchedWires) {
       showUnmatchedWires()
 
-      def dumpWires(wires: Seq[String], fileName: String) {
+      def dumpWires(wires: Seq[String], fileName: String): Unit = {
         val out = new PrintStream(new File(fileName))
         for (name <- wires) {
           out.println(name)

--- a/src/test/scala/treadle/DynamicMemorySearch.scala
+++ b/src/test/scala/treadle/DynamicMemorySearch.scala
@@ -71,7 +71,7 @@ class DynamicMemorySearch extends AnyFreeSpec with Matchers with LazyLogging {
         tester.poke("io_en", 0)
       }
 
-      def checkSearch(searchValue: BigInt): Unit = {
+      def checkSearch(searchValue: Int): Unit = {
         val expectedIndex = list.indexOf(searchValue) match {
           case -1 => list.length
           case x  => x


### PR DESCRIPTION
Treadle never needed `-Xsource:2.11`, so I deleted it. It also doesn't need macros-paradise, so I deleted that from the Mill build.

Ironically, this is _almost_ binary compatible for 2.11 and 2.12, but deleting the import in `src/main/scala/treadle/ScalaBlackBox.scala` changes some return types from `collection.Set` to `collection.immutable.Set`. This change could possibly be made in a fully binary incompatible way, but it's not really needed until 1.5 (since Chisel almost certainly will break binary compatibility in adding 2.13). I figured it was better to fix that API because I suspect that using `collection.Set` was unintentional unless @chick tells me otherwise.