### PR TITLE
Proof of concept for coverage statement counting in Treadle

### DIFF
--- a/src/main/scala/treadle/TreadleOptions.scala
+++ b/src/main/scala/treadle/TreadleOptions.scala
@@ -40,6 +40,19 @@ case object VcdShowUnderScoredAnnotation extends NoTargetAnnotation with Treadle
 }
 
 /**
+  * Tells treadle to write coverage report in CSV format after simulation
+  */
+case object WriteCoverageCSVAnnotation extends NoTargetAnnotation with TreadleOption with HasShellOptions {
+  val options: Seq[ShellOption[_]] = Seq(
+    new ShellOption[Unit](
+      longOption = "tr-write-coverage-csv",
+      toAnnotationSeq = _ => Seq(WriteCoverageCSVAnnotation),
+      helpText = "writes coverage report in CSV format after simulation, filename will be based on top-name"
+    )
+  )
+}
+
+/**
   *  Tells treadle to execute verbosely
   */
 case object VerboseAnnotation extends NoTargetAnnotation with TreadleOption with HasShellOptions {

--- a/src/main/scala/treadle/TreadleTester.scala
+++ b/src/main/scala/treadle/TreadleTester.scala
@@ -381,6 +381,12 @@ class TreadleTester(annotationSeq: AnnotationSeq) {
     expectationsMet += 1
   }
 
+  /** Returns the number of times every cover statement has been true on a clock edge. */
+  def getCoverage(): List[(String, Long)] = {
+    val cov = engine.symbolTable.verifyOps.filter(_.op == firrtl.ir.Formal.Cover)
+    cov.map(c => c.symbol.name -> c.coverCount).toList
+  }
+
   def waveformValues(
     symbolNames: Array[String] = Array[String](),
     startCycle:  Int = 0,

--- a/src/main/scala/treadle/TreadleTester.scala
+++ b/src/main/scala/treadle/TreadleTester.scala
@@ -56,6 +56,7 @@ class TreadleTester(annotationSeq: AnnotationSeq) {
   val resetName: String = annotationSeq.collectFirst { case ResetNameAnnotation(rn) => rn }.getOrElse("reset")
   private val clockInfo = annotationSeq.collectFirst { case ClockInfoAnnotation(cia) => cia }.getOrElse(Seq.empty)
   private val writeVcd = annotationSeq.exists { case WriteVcdAnnotation => true; case _ => false }
+  private val writeCoverageReport = annotationSeq.exists { case WriteCoverageCSVAnnotation => true; case _ => false }
   val vcdShowUnderscored: Boolean = annotationSeq.exists { case VcdShowUnderScoredAnnotation => true; case _ => false }
   private val callResetAtStartUp = annotationSeq.exists { case CallResetAtStartupAnnotation => true; case _ => false }
   val topName: String = annotationSeq.collectFirst { case OutputFileAnnotation(ofn) => ofn }.getOrElse(engine.ast.main)
@@ -471,7 +472,7 @@ class TreadleTester(annotationSeq: AnnotationSeq) {
 
 
   def finish: Boolean = {
-    engine.finish()
+    engine.finish(writeCoverageReport)
     engine.writeVCD()
     isOK
   }

--- a/src/main/scala/treadle/TreadleTester.scala
+++ b/src/main/scala/treadle/TreadleTester.scala
@@ -56,7 +56,7 @@ class TreadleTester(annotationSeq: AnnotationSeq) {
   val resetName: String = annotationSeq.collectFirst { case ResetNameAnnotation(rn) => rn }.getOrElse("reset")
   private val clockInfo = annotationSeq.collectFirst { case ClockInfoAnnotation(cia) => cia }.getOrElse(Seq.empty)
   private val writeVcd = annotationSeq.exists { case WriteVcdAnnotation => true; case _ => false }
-  private val writeCoverageReport = annotationSeq.exists { case WriteCoverageCSVAnnotation => true; case _ => false }
+  private val writeCoverageReport = annotationSeq.contains(WriteCoverageCSVAnnotation)
   val vcdShowUnderscored: Boolean = annotationSeq.exists { case VcdShowUnderScoredAnnotation => true; case _ => false }
   private val callResetAtStartUp = annotationSeq.exists { case CallResetAtStartupAnnotation => true; case _ => false }
   val topName: String = annotationSeq.collectFirst { case OutputFileAnnotation(ofn) => ofn }.getOrElse(engine.ast.main)

--- a/src/main/scala/treadle/executable/ExecutionEngine.scala
+++ b/src/main/scala/treadle/executable/ExecutionEngine.scala
@@ -493,13 +493,13 @@ class ExecutionEngine(
   Currently this telling black boxes to finish up things if they need to
   and have the coverage counts recorded if they exist.
    */
-  def finish(): Unit = {
+  def finish(writeCoverageReport: Boolean = false): Unit = {
     symbols.foreach { symbol =>
       symbolTable.getBlackboxImplementation(symbol).foreach { blackBox =>
         blackBox.finish()
       }
     }
-    if (symbolTable.verifyOps.nonEmpty) {
+    if (writeCoverageReport && symbolTable.verifyOps.nonEmpty) {
       val text = symbolTable.verifyOps.map { verifyOp =>
         s"${verifyOp.info.toString.trim},${verifyOp.message.escape},${verifyOp.clockCount},${verifyOp.coverCount}"
       }.sorted.mkString("\n")

--- a/src/main/scala/treadle/executable/ExecutionEngine.scala
+++ b/src/main/scala/treadle/executable/ExecutionEngine.scala
@@ -2,13 +2,14 @@
 
 package treadle.executable
 
-import java.io.PrintWriter
+import java.io.{File, PrintWriter}
 
 import firrtl.annotations.ReferenceTarget
 import firrtl.annotations.TargetToken.Instance
 import firrtl.ir.{Circuit, NoInfo}
 import firrtl.options.StageOptions
 import firrtl.options.Viewer.view
+import firrtl.stage.OutputFileAnnotation
 import firrtl.{AnnotationSeq, MemKind, PortKind, RegKind}
 import logger.LazyLogging
 import treadle._
@@ -33,6 +34,11 @@ class ExecutionEngine(
 
   var vcdOption:   Option[VCD] = None
   var vcdFileName: String = ""
+
+  // use the generated file root to create files in working dir with desired suffixes
+  private val topName: String = annotationSeq.collectFirst { case OutputFileAnnotation(ofn) => ofn }.getOrElse(ast.main)
+  private val stageOptions = view[StageOptions](annotationSeq)
+  val generatedFileRoot: String = stageOptions.getBuildFileName(topName)
 
   val expressionViewRenderer = new ExpressionViewRenderer(
     dataStore,
@@ -79,8 +85,7 @@ class ExecutionEngine(
     scheduler.setVerboseAssign(verbose)
   }
 
-  /**
-    * turns on evaluator debugging.  Can make output quite
+  /** turns on evaluator debugging.  Can make output quite
     * verbose.
     *
     * @param isVerbose  The desired verbose setting
@@ -256,8 +261,7 @@ class ExecutionEngine(
     }
   }
 
-  /**
-    * Update the dataStore with the supplied information.
+  /** Update the dataStore with the supplied information.
     * IMPORTANT: This should never be used internally.
     *
     * @param name  name of value to set
@@ -328,8 +332,7 @@ class ExecutionEngine(
     value
   }
 
-  /**
-    * Update the dataStore with the supplied information.
+  /** Update the dataStore with the supplied information.
     * IMPORTANT: This should never be used internally.
     *
     * @param symbol symbol to set
@@ -458,8 +461,7 @@ class ExecutionEngine(
 
   private val stopHappenedSymbolOpt = symbolTable.get(StopOp.stopHappenedName)
 
-  /**
-    * returns that value specified by a StopOp when
+  /** returns that value specified by a StopOp when
     * its condition is satisfied.  Only defined when
     * circuit is currently stopped.
     * @return
@@ -478,8 +480,7 @@ class ExecutionEngine(
     }
   }
 
-  /**
-    * Is the circuit currently stopped.  StopOp throws a
+  /** Is the circuit currently stopped.  StopOp throws a
     * Stop
     * @return
     */
@@ -487,11 +488,24 @@ class ExecutionEngine(
     lastStopResult.isDefined
   }
 
+  /*
+  This is where things should go that need to be done at the end of the run.
+  Currently this telling black boxes to finish up things if they need to
+  and have the coverage counts recorded if they exist.
+   */
   def finish(): Unit = {
     symbols.foreach { symbol =>
       symbolTable.getBlackboxImplementation(symbol).foreach { blackBox =>
         blackBox.finish()
       }
+    }
+    if (symbolTable.verifyOps.nonEmpty) {
+      val text = symbolTable.verifyOps.map { verifyOp =>
+        s"${verifyOp.info.toString.trim},${verifyOp.message.escape},${verifyOp.clockCount},${verifyOp.coverCount}"
+      }.sorted.mkString("\n")
+      val writer = new PrintWriter(new File(generatedFileRoot + ".coverage.txt"))
+      writer.write(text)
+      writer.close()
     }
   }
 
@@ -554,8 +568,7 @@ object ExecutionEngine extends LazyLogging {
   val VCDHookName = "log-vcd"
 
   //scalastyle:off method.length
-  /**
-    * Factory to create an execution engine
+  /** Factory to create an execution engine
     * @param annotationSeq  annotations control all
     * @param wallTime       external synthetic simple time
     * @return

--- a/src/main/scala/treadle/executable/ExpressionCompiler.scala
+++ b/src/main/scala/treadle/executable/ExpressionCompiler.scala
@@ -954,7 +954,8 @@ class ExpressionCompiler(
                   message,
                   clockTransitionGetter,
                   intPredicateExpression,
-                  intEnableExpression
+                  intEnableExpression,
+                  Formal.Cover
                 )
                 symbolTable.verifyOps += verifyOp
                 addAssigner(verifyOp)

--- a/src/main/scala/treadle/executable/ExpressionViewBuilder.scala
+++ b/src/main/scala/treadle/executable/ExpressionViewBuilder.scala
@@ -303,12 +303,22 @@ class ExpressionViewBuilder(
         case print @ Print(info, stringLiteral, argExpressions, clockExpression, enableExpression) =>
           expressionViews(symbolTable.printToPrintInfo(print).printSymbol) = processExpression(enableExpression)
 
+        case verify @ Verification(
+              Formal.Cover,
+              info,
+              clockExpression,
+              predicateExpression,
+              enableExpression,
+              message
+            ) =>
+          expressionViews(symbolTable.verifyToVerifyInfo(verify).verifySymbol) = processExpression(predicateExpression)
+
         case EmptyStmt =>
         case conditionally: Conditionally =>
           // logger.debug(s"got a conditionally $conditionally")
           throw TreadleException(s"conditionally unsupported in engine $conditionally")
         case _ =>
-          println(s"TODO: Unhandled statement $statement")
+          println(s"ExpressionViewBuilder:TODO: Unhandled statement $statement")
       }
     }
     // scalastyle:on

--- a/src/main/scala/treadle/executable/SymbolTable.scala
+++ b/src/main/scala/treadle/executable/SymbolTable.scala
@@ -51,7 +51,7 @@ class SymbolTable(val nameToSymbol: mutable.HashMap[String, Symbol]) {
   val stopToStopInfo:     mutable.HashMap[Stop, StopInfo] = new mutable.HashMap[Stop, StopInfo]
   val printToPrintInfo:   mutable.HashMap[Print, PrintInfo] = new mutable.HashMap[Print, PrintInfo]
   val verifyToVerifyInfo: mutable.HashMap[Verification, VerifyInfo] = new mutable.HashMap[Verification, VerifyInfo]
-  val verifyOps:          mutable.ListBuffer[VerifyOp] = new mutable.ListBuffer[VerifyOp].empty
+  val verifyOps:          mutable.ListBuffer[VerifyOp] = new mutable.ListBuffer[VerifyOp]
 
   def isRegister(name:      String): Boolean = registerNames.contains(name)
   def isTopLevelInput(name: String): Boolean = inputPortsNames.contains(name)

--- a/src/main/scala/treadle/executable/SymbolTable.scala
+++ b/src/main/scala/treadle/executable/SymbolTable.scala
@@ -183,10 +183,12 @@ object SymbolTable extends LazyLogging {
       s"/print${printSymbolsFound - 1}"
     }
 
-    var verificationSymbolsFound: Int = 0
-    def makeVerifyName(): String = {
-      verificationSymbolsFound += 1
-      s"/verify${verificationSymbolsFound - 1}"
+    // cover symbols are scoped thus we have a counter for every prefix
+    val coverSymbolsFound = mutable.HashMap[String, Int]()
+    def makeCoverName(prefix: String): String = {
+      val id = coverSymbolsFound.getOrElse(prefix, 0)
+      coverSymbolsFound.put(prefix, id + 1)
+      s"cover${id}"
     }
 
     val nameToSymbol = new mutable.HashMap[String, Symbol]()
@@ -468,7 +470,7 @@ object SymbolTable extends LazyLogging {
           /* do something good here */
           getClockSymbol(clockExpression) match {
             case Some(_) =>
-              val verifySymbolName = makeVerifyName()
+              val verifySymbolName = expand(makeCoverName(modulePrefix))
               val verifySymbol =
                 Symbol(verifySymbolName, IntSize, UnsignedInt, WireKind, 1, 1, UIntType(IntWidth(1)), info)
               addSymbol(verifySymbol)

--- a/src/main/scala/treadle/executable/SymbolTable.scala
+++ b/src/main/scala/treadle/executable/SymbolTable.scala
@@ -480,8 +480,8 @@ object SymbolTable extends LazyLogging {
               addDependency(verifySymbol, expressionToReferences(predicateExpression))
 
               lastVerifyInModule.get(module) match {
-                case Some(lastPrintfSymbol) =>
-                  addDependency(verifySymbol, Set(lastPrintfSymbol))
+                case Some(lastVerifySymbol) =>
+                  addDependency(verifySymbol, Set(lastVerifySymbol))
                 case _ =>
               }
               lastVerifyInModule(module) = verifySymbol

--- a/src/main/scala/treadle/executable/VerifyOp.scala
+++ b/src/main/scala/treadle/executable/VerifyOp.scala
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package treadle.executable
+
+import firrtl.WireKind
+import firrtl.ir._
+
+/** This handles the processing of coverage statements
+  *
+  * @param symbol            machine generated symbol for each statement encountered
+  * @param info              source information
+  * @param message           message associated with statement
+  * @param clockTransition   updates clockCount when this is is PosEdge
+  * @param predicate         only increments coverCount if this is true
+  * @param enable            only increments coverCount if this is true
+  */
+case class VerifyOp(
+  symbol:          Symbol,
+  info:            Info,
+  message:         StringLit,
+  clockTransition: ClockTransitionGetter,
+  predicate:       IntExpressionResult,
+  enable:          IntExpressionResult)
+    extends Assigner {
+
+  var clockCount: Long = 0
+  var coverCount: Long = 0
+
+  def run: FuncUnit = {
+    val conditionValue = predicate.apply() > 0
+    val enableValue = enable.apply() > 0
+
+    if (clockTransition.isPosEdge) {
+      clockCount += 1
+      if (conditionValue && enableValue) {
+        coverCount += 1
+      }
+
+    }
+
+    () => ()
+  }
+}
+
+object VerifyOp {
+  val VerifyOpSymbol: Symbol = Symbol("verifyop", IntSize, UnsignedInt, WireKind, 1, 1, UIntType(IntWidth(1)), NoInfo)
+}
+
+case class VerifyInfo(verifySymbol: Symbol, cardinal: Int) extends Ordered[VerifyInfo] {
+  override def compare(that: VerifyInfo): Int = that.cardinal - this.cardinal
+}

--- a/src/main/scala/treadle/executable/VerifyOp.scala
+++ b/src/main/scala/treadle/executable/VerifyOp.scala
@@ -20,7 +20,8 @@ case class VerifyOp(
   message:         StringLit,
   clockTransition: ClockTransitionGetter,
   predicate:       IntExpressionResult,
-  enable:          IntExpressionResult)
+  enable:          IntExpressionResult,
+  op: Formal.Value)
     extends Assigner {
 
   var clockCount: Long = 0

--- a/src/main/scala/treadle/executable/VerifyOp.scala
+++ b/src/main/scala/treadle/executable/VerifyOp.scala
@@ -27,15 +27,14 @@ case class VerifyOp(
   var coverCount: Long = 0
 
   def run: FuncUnit = {
-    val conditionValue = predicate.apply() > 0
-    val enableValue = enable.apply() > 0
-
     if (clockTransition.isPosEdge) {
       clockCount += 1
+      val conditionValue = predicate.apply() > 0
+      val enableValue = enable.apply() > 0
+
       if (conditionValue && enableValue) {
         coverCount += 1
       }
-
     }
 
     () => ()

--- a/src/main/scala/treadle/stage/phases/HandleFormalStatements.scala
+++ b/src/main/scala/treadle/stage/phases/HandleFormalStatements.scala
@@ -70,8 +70,6 @@ class HandleFormalStatements
         case Verification(Formal.Assert, info, clk, cond, en, msg) =>
           makeBlock(info, clk, makeTrigger(cond, en), msg, 0x41)
 
-        case Verification(Formal.Cover, _, _, _, _, _) =>
-          EmptyStmt
         case t => t.mapStmt(assertAssumption)
       }
     }

--- a/src/main/scala/treadle/utils/CoveragePrettyPrinter.scala
+++ b/src/main/scala/treadle/utils/CoveragePrettyPrinter.scala
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package treadle.utils
+
+import firrtl.annotations.{Annotation, NoTargetAnnotation}
+import firrtl.options.{HasShellOptions, Shell, ShellOption, Stage, StageMain, Unserializable}
+import firrtl.{annoSeqToSeq, AnnotationSeq, FileUtils}
+import logger.Logger
+
+/** A Prototype rendering program to add coverage information to the
+  * printout of a firrtl file that contains coverage statements and
+  * that has been run through treadle
+  *
+  * TODO: Possibly try to do this with firrtl transforms instead of text based processing
+  * TODO: May need to also match on coverage message
+  */
+class CoveragePrettyPrinter extends Stage {
+  override val shell: Shell = new Shell("coverage-pretty-printer") with CoveragePrettyPrinterCli
+
+  private val InfoPattern = """^(.*)@\[(.*)]$""".r
+
+  override def run(annotations: AnnotationSeq): AnnotationSeq = {
+    Logger.makeScope(annotations) {
+      val firrtlFileName: String = annotations.collectFirst { case c: CoveragePrettyPrinterSourceName =>
+        c.name
+      }.getOrElse {
+        println(s"You must specify -cpp-coverage-file and -cpp-firrtl-file")
+        System.exit(1)
+        throw new Exception()
+      }
+      val coverageFileName: String = annotations.collectFirst { case c: CoveragePrettyPrinterDataName =>
+        c.name
+      }.getOrElse {
+        println(s"You must specify -cpp-coverage-file and -cpp-firrtl-file")
+        System.exit(1)
+        throw new Exception()
+      }
+      val firrtlSource = FileUtils.getLines(firrtlFileName)
+      val coverageData = FileUtils.getLines(coverageFileName)
+      val printLineNumbers = annotations.contains(PrintLineNumbers)
+      val noColors = annotations.contains(NoColors)
+
+      val coverageDataMap = coverageData.flatMap { line =>
+        if (line.trim.isEmpty || line.trim.startsWith("#")) {
+          None
+        } else {
+          line.split(",").toList match {
+            case info :: _ :: clockCyclesString :: coverageCountString :: Nil =>
+              val coverageCount = coverageCountString.toInt
+              val clockCycles = clockCyclesString.toInt
+              Some(
+                info.trim -> CoverageAndColor(
+                  s"COV($clockCycles,$coverageCount)",
+                  if (noColors) { "" }
+                  else if (coverageCount == 0) { Console.RED }
+                  else if (coverageCount < clockCycles) { Console.CYAN }
+                  else { Console.GREEN }
+                )
+              )
+            case _ =>
+              None
+          }
+        }
+      }.toMap
+
+      def maybeLineNUmber(n: Int): String = {
+        if (printLineNumbers) { f"$n%4d" }
+        else { "" }
+      }
+
+      firrtlSource.zipWithIndex.foreach { case (line, lineNumber) =>
+        line match {
+          case InfoPattern(code, info) =>
+            val infoForm = s"""@[$info]"""
+            coverageDataMap.get(infoForm) match {
+              case Some(CoverageAndColor(coverageString, color)) =>
+                println(f"$color${maybeLineNUmber(lineNumber)}$code $infoForm   $coverageString${Console.RESET}")
+              case _ =>
+                println(f"${maybeLineNUmber(lineNumber)}$code $infoForm")
+            }
+          case _ =>
+            println(f"${maybeLineNUmber(lineNumber)}$line")
+        }
+      }
+    }
+    annotations
+  }
+}
+
+/** This is the primary entry point for running the Treadle Repl
+  */
+object CoveragePrettyPrinterMain extends StageMain(new CoveragePrettyPrinter)
+
+sealed trait CoveragePrettyPrinterOption extends Unserializable { this: Annotation => }
+
+case class CoveragePrettyPrinterSourceName(name: String) extends NoTargetAnnotation with CoveragePrettyPrinterOption
+
+object CoveragePrettyPrinterSourceName extends HasShellOptions {
+  val options: Seq[ShellOption[_]] = Seq(
+    new ShellOption[String](
+      longOption = "cpp-firrtl-file",
+      shortOption = Some("cff"),
+      toAnnotationSeq = (s: String) => Seq(CoveragePrettyPrinterSourceName(s)),
+      helpText = "firrtl file to be combined with coverage report"
+    )
+  )
+}
+
+case class CoveragePrettyPrinterDataName(name: String) extends NoTargetAnnotation with CoveragePrettyPrinterOption
+
+object CoveragePrettyPrinterDataName extends HasShellOptions {
+  val options: Seq[ShellOption[_]] = Seq(
+    new ShellOption[String](
+      longOption = "cpp-coverage-file",
+      shortOption = Some("ccf"),
+      toAnnotationSeq = (s: String) => Seq(CoveragePrettyPrinterDataName(s)),
+      helpText = "coverage report file to be combined with firrtl file"
+    )
+  )
+}
+
+case object PrintLineNumbers extends HasShellOptions with NoTargetAnnotation with CoveragePrettyPrinterOption {
+  val options: Seq[ShellOption[_]] = Seq(
+    new ShellOption[Unit](
+      longOption = "print-line-numbers",
+      shortOption = Some("pln"),
+      toAnnotationSeq = _ => Seq(PrintLineNumbers),
+      helpText = "print line numbers in output"
+    )
+  )
+}
+
+case object NoColors extends HasShellOptions with NoTargetAnnotation with CoveragePrettyPrinterOption {
+  val options: Seq[ShellOption[_]] = Seq(
+    new ShellOption[Unit](
+      longOption = "no-colors",
+      shortOption = Some("nc"),
+      toAnnotationSeq = _ => Seq(NoColors),
+      helpText = "print line numbers in output"
+    )
+  )
+}
+
+trait CoveragePrettyPrinterCli { this: Shell =>
+  parser.note("TreadleRepl specific options")
+
+  Seq(
+    CoveragePrettyPrinterSourceName,
+    CoveragePrettyPrinterDataName,
+    PrintLineNumbers,
+    NoColors
+  ).foreach(_.addOptions(parser))
+}
+
+case class CoverageAndColor(coverageString: String, color: String)

--- a/src/test/resources/HasCoverStatements.fir
+++ b/src/test/resources/HasCoverStatements.fir
@@ -1,0 +1,33 @@
+circuit HasCoverStatements :
+  module HasCoverStatements :
+    input clock : Clock
+    input reset : UInt<1>
+    output out : UInt<1>
+
+    reg out_reg : UInt<1>, clock with :
+      reset => (reset, UInt<1>("h0")) @[VerificationSpec.scala 29:24]
+    node _out_reg_T = eq(out_reg, UInt<1>("h0")) @[VerificationSpec.scala 30:14]
+    out_reg <= _out_reg_T @[VerificationSpec.scala 30:11]
+    cover(clock, out_reg, UInt<1>("h1"), "register 0 cover") @[VerificationSpec.scala 42:19]
+    node _out_T = asClock(out_reg) @[VerificationSpec.scala 32:11]
+    reg out_reg_1 : UInt<1>, _out_T with :
+      reset => (reset, UInt<1>("h0")) @[VerificationSpec.scala 29:24]
+    node _out_reg_T_1 = eq(out_reg_1, UInt<1>("h0")) @[VerificationSpec.scala 30:14]
+    out_reg_1 <= _out_reg_T_1 @[VerificationSpec.scala 30:11]
+    cover(_out_T, out_reg_1, UInt<1>("h1"), "register 1 cover") @[VerificationSpec.scala 52:19]
+    node _out_T_1 = asClock(out_reg_1) @[VerificationSpec.scala 32:11]
+    reg out_reg_2 : UInt<1>, _out_T_1 with :
+      reset => (reset, UInt<1>("h0")) @[VerificationSpec.scala 29:24]
+    node _out_reg_T_2 = eq(out_reg_2, UInt<1>("h0")) @[VerificationSpec.scala 30:14]
+    out_reg_2 <= _out_reg_T_2 @[VerificationSpec.scala 30:11]
+    cover(_out_T_1, out_reg_2, UInt<1>("h1"), "register 2 cover") @[VerificationSpec.scala 62:19]
+    node _out_T_2 = asClock(out_reg_2) @[VerificationSpec.scala 32:11]
+    reg out_reg_3 : UInt<1>, _out_T_2 with :
+      reset => (reset, UInt<1>("h0")) @[VerificationSpec.scala 29:24]
+    node _out_reg_T_3 = eq(out_reg_3, UInt<1>("h0")) @[VerificationSpec.scala 30:14]
+    out_reg_3 <= _out_reg_T_3 @[VerificationSpec.scala 30:11]
+    cover(_out_T_2, out_reg_3, UInt<1>("h1"), "register 3 cover") @[VerificationSpec.scala 72:19]
+    node _out_T_3 = asClock(out_reg_3) @[VerificationSpec.scala 32:11]
+    node _out_T_4 = asUInt(_out_T_3) @[VerificationSpec.scala 34:5]
+    node _out_T_5 = bits(_out_T_4, 0, 0) @[VerificationSpec.scala 34:5]
+    out <= _out_T_5 @[VerificationSpec.scala 27:7]

--- a/src/test/resources/HasCoverStatements.fir
+++ b/src/test/resources/HasCoverStatements.fir
@@ -31,3 +31,12 @@ circuit HasCoverStatements :
     node _out_T_4 = asUInt(_out_T_3) @[VerificationSpec.scala 34:5]
     node _out_T_5 = bits(_out_T_4, 0, 0) @[VerificationSpec.scala 34:5]
     out <= _out_T_5 @[VerificationSpec.scala 27:7]
+    inst c of child
+    c.clock <= clock
+    c.in <= out_reg_3
+
+  module child:
+    input clock : Clock
+    input in : UInt<1>
+    cover(clock, not(in), UInt(1), "cov0")
+    cover(clock, not(not(in)), UInt(1), "cov1")

--- a/src/test/scala/treadle/FormalCoverSpec.scala
+++ b/src/test/scala/treadle/FormalCoverSpec.scala
@@ -32,6 +32,7 @@ class FormalCoverSpec extends AnyFreeSpec with Matchers {
     }
   }
 
+  val ReportAnno = Seq(WriteCoverageCSVAnnotation)
 
   "cover statements should produce a report" in {
     // report will go in coverageFileName so delete it if it already exists
@@ -40,7 +41,8 @@ class FormalCoverSpec extends AnyFreeSpec with Matchers {
       new File(coverageFileName).delete()
     }
 
-    TreadleTestHarness(Seq(FirrtlSourceAnnotation(firrtlSource))) { tester =>
+    val annos = Seq(FirrtlSourceAnnotation(firrtlSource)) ++ ReportAnno
+    TreadleTestHarness(annos) { tester =>
       tester.step(10)
     }
     new File(coverageFileName).exists() should be(true)
@@ -66,7 +68,8 @@ class FormalCoverSpec extends AnyFreeSpec with Matchers {
       new File(coverageFileName).delete()
     }
 
-    TreadleTestHarness(Seq(FirrtlSourceAnnotation(firrtlSource))) { tester =>
+    val annos = Seq(FirrtlSourceAnnotation(firrtlSource)) ++ ReportAnno
+    TreadleTestHarness(annos) { tester =>
       tester.step(10)
     }
     new File(coverageFileName).exists() should be(true)

--- a/src/test/scala/treadle/FormalCoverSpec.scala
+++ b/src/test/scala/treadle/FormalCoverSpec.scala
@@ -47,6 +47,8 @@ class FormalCoverSpec extends AnyFreeSpec with Matchers {
 
     val lines = FileUtils.getLines(coverageFileName)
     val expectedLines = Seq(
+      ""","cov0",10,2""",
+      ""","cov1",10,8""",
       """@[VerificationSpec.scala 42:19],"register 0 cover",10,5""",
       """@[VerificationSpec.scala 52:19],"register 1 cover",5,3""",
       """@[VerificationSpec.scala 62:19],"register 2 cover",3,2""",

--- a/src/test/scala/treadle/FormalCoverSpec.scala
+++ b/src/test/scala/treadle/FormalCoverSpec.scala
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package treadle
+
+import java.io.{ByteArrayOutputStream, File, PrintStream}
+
+import firrtl.FileUtils
+import firrtl.stage.FirrtlSourceAnnotation
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import treadle.utils.CoveragePrettyPrinterMain
+
+class FormalCoverSpec extends AnyFreeSpec with Matchers {
+  private val stream = getClass.getResourceAsStream("/HasCoverStatements.fir")
+  private val firrtlSource = scala.io.Source.fromInputStream(stream).getLines().mkString("\n")
+
+  "cover statements should produce a report" in {
+    // report will go in coverageFileName so delete it if it already exists
+    val coverageFileName = "test_run_dir/HasCoverStatements/HasCoverStatements.coverage.txt"
+    if (new File(coverageFileName).exists()) {
+      new File(coverageFileName).delete()
+    }
+
+    TreadleTestHarness(Seq(FirrtlSourceAnnotation(firrtlSource))) { tester =>
+      tester.step(10)
+    }
+    new File(coverageFileName).exists() should be(true)
+
+    val lines = FileUtils.getLines(coverageFileName)
+    val expectedLines = Seq(
+      """@[VerificationSpec.scala 42:19],"register 0 cover",10,5""",
+      """@[VerificationSpec.scala 52:19],"register 1 cover",5,3""",
+      """@[VerificationSpec.scala 62:19],"register 2 cover",3,2""",
+      """@[VerificationSpec.scala 72:19],"register 3 cover",2,1"""
+    )
+    lines.zip(expectedLines).foreach { case (a, b) =>
+      a should be(b)
+    }
+  }
+
+  "pretty printer provided can show coverage on firrtl source" in {
+    val firrtlFileName = "src/test/resources/HasCoverStatements.fir"
+    val coverageFileName = "test_run_dir/HasCoverStatements/HasCoverStatements.coverage.txt"
+    if (new File(coverageFileName).exists()) {
+      new File(coverageFileName).delete()
+    }
+
+    TreadleTestHarness(Seq(FirrtlSourceAnnotation(firrtlSource))) { tester =>
+      tester.step(10)
+    }
+    new File(coverageFileName).exists() should be(true)
+
+    val outputBuffer = new ByteArrayOutputStream()
+    Console.withOut(new PrintStream(outputBuffer)) {
+      CoveragePrettyPrinterMain.main(
+        Array(
+          "--cpp-firrtl-file",
+          firrtlFileName,
+          "--cpp-coverage-file",
+          coverageFileName
+        )
+      )
+    }
+    val outputLines = outputBuffer.toString
+
+    val expectedLines = Seq(
+      """cover(clock, out_reg, UInt<1>("h1"), "register 0 cover")  @[VerificationSpec.scala 42:19]   COV(10,5)""",
+      """cover(_out_T, out_reg_1, UInt<1>("h1"), "register 1 cover")  @[VerificationSpec.scala 52:19]   COV(5,3)""",
+      """cover(_out_T_1, out_reg_2, UInt<1>("h1"), "register 2 cover")  @[VerificationSpec.scala 62:19]   COV(3,2)""",
+      """cover(_out_T_2, out_reg_3, UInt<1>("h1"), "register 3 cover")  @[VerificationSpec.scala 72:19]   COV(2,1)"""
+    )
+    expectedLines.foreach { expectedLine =>
+      outputLines should include(expectedLine)
+    }
+  }
+}

--- a/src/test/scala/treadle/VerificationSpec.scala
+++ b/src/test/scala/treadle/VerificationSpec.scala
@@ -41,7 +41,8 @@ class VerificationSpec extends AnyFreeSpec with Matchers {
   }
 
   "verification formal statements should be handled as follows" - {
-    "cover statements are removed" in {
+    // new cover statement handling changes this.
+    "cover statements are removed" ignore {
       val output = new ByteArrayOutputStream()
       Console.withOut(new PrintStream(output)) {
         TreadleTestHarness(Seq(FirrtlSourceAnnotation(input()), ShowFirrtlAtLoadAnnotation)) { _ => }


### PR DESCRIPTION
This creates a new treadle execution element, `VerifyOp`, that keeps count of all the number of times a coverage statements has seen a rising edge of its clock and how many times the enable and predicate are both true.

At the end of the run the a CSV text file is created in the working directory <circuit-name>.coverage.txt

Additionally a small pretty printer, `CoveragePrettyPrinterMain`, that can take the coverage CSV file and the original firrtl file and produces a text rendering of the firrtl with coverage info added at the end of the lines of coverage statements.
By default those lines are color code as follows
- red means no coverage hits
- cyan means hits but not always
- green means coverage hits equals

Specifically
- Add a couple of hooks to execution engine to help with coverage file generation
- Execution compiler adds VerifyOp's to the the execution stack
- Symbol Table builds lists of Coverage statements encountered
- ExpressionViewBuilder has handling code also
- Added some hints to disambiguate who can't handle a class of Firrtl statements