### PR TITLE
Use Statement Names from Firrtl

### DIFF
--- a/src/main/scala/treadle/stage/phases/HandleFormalStatements.scala
+++ b/src/main/scala/treadle/stage/phases/HandleFormalStatements.scala
@@ -8,7 +8,7 @@ import firrtl.ir._
 import firrtl.options.{Dependency, RegisteredTransform, ShellOption}
 import firrtl.passes.ExpandWhensAndCheck
 import firrtl.stage.TransformManager.TransformDependency
-import firrtl.{CircuitState, DependencyAPIMigration, Transform}
+import firrtl.{CircuitState, DependencyAPIMigration, Namespace, Transform}
 
 /** This controls the handling of the verification formal statements for treadle.
   * currently it does the following
@@ -41,41 +41,44 @@ class HandleFormalStatements
   )
 
   def run(c: Circuit, dropAssumes: Boolean): Circuit = {
-    def assertAssumption(s: Statement): Statement = {
+    def assertAssumption(namespace: Namespace, s: Statement): Statement = {
       def makeTrigger(cond: Expression, en: Expression): Expression = {
         val notOfCondition = DoPrim(Not, Seq(cond), Nil, cond.tpe)
         DoPrim(And, Seq(notOfCondition, en), Nil, cond.tpe)
       }
 
-      def makeBlock(info: Info, clk: Expression, trigger: Expression, msg: StringLit, stopValue: Int): Statement = {
-        val stop = Stop(info, ret = stopValue, clk, trigger)
+      def makeBlock(info: Info, name: String, clk: Expression, trigger: Expression, msg: StringLit, stopValue: Int): Statement = {
+        // We intentionally name the stop statement the same as the assert/assume statement being replaced so that
+        // it can be more easily correlated.
+        val stop = Stop(info, ret = stopValue, clk, trigger, name = name)
         msg match {
           case StringLit("") => stop
           case _ =>
             Block(
-              Print(info, msg, Seq.empty, clk, trigger),
+              Print(info, msg, Seq.empty, clk, trigger, name = namespace.newName(name + "_print")),
               stop
             )
         }
       }
 
       s match {
-        case Verification(Formal.Assume, info, clk, cond, en, msg) =>
+        case v @ Verification(Formal.Assume, info, clk, cond, en, msg) =>
           if (dropAssumes) {
             EmptyStmt
           } else {
-            makeBlock(info, clk, makeTrigger(cond, en), msg, 0x42)
+            makeBlock(info, v.name, clk, makeTrigger(cond, en), msg, 0x42)
           }
 
-        case Verification(Formal.Assert, info, clk, cond, en, msg) =>
-          makeBlock(info, clk, makeTrigger(cond, en), msg, 0x41)
+        case v @ Verification(Formal.Assert, info, clk, cond, en, msg) =>
+          makeBlock(info, v.name, clk, makeTrigger(cond, en), msg, 0x41)
 
-        case t => t.mapStmt(assertAssumption)
+        case t => t.mapStmt(assertAssumption(namespace, _))
       }
     }
 
     c.mapModule(mod => {
-      mod.mapStmt(assertAssumption)
+      val namespace = Namespace(mod)
+      mod.mapStmt(assertAssumption(namespace, _))
     })
   }
 

--- a/src/main/scala/treadle/stage/phases/PrepareAst.scala
+++ b/src/main/scala/treadle/stage/phases/PrepareAst.scala
@@ -15,6 +15,7 @@ import treadle.utils.{AugmentPrintf, FixupOps}
   */
 class PrepareAst extends Phase {
   private val targets = Seq(
+    Dependency(firrtl.transforms.EnsureNamedStatements),
     Dependency(AddCoverageExpressions),
     Dependency[BlackBoxSourceHelper],
     Dependency[FixupOps],

--- a/src/test/resources/HasCoverStatements.fir
+++ b/src/test/resources/HasCoverStatements.fir
@@ -38,5 +38,5 @@ circuit HasCoverStatements :
   module child:
     input clock : Clock
     input in : UInt<1>
-    cover(clock, not(in), UInt(1), "cov0")
-    cover(clock, not(not(in)), UInt(1), "cov1")
+    cover(clock, not(in), UInt(1), "cov0") : cov0
+    cover(clock, not(not(in)), UInt(1), "cov1") : cov1_this_is_custom

--- a/src/test/scala/treadle/FormalCoverSpec.scala
+++ b/src/test/scala/treadle/FormalCoverSpec.scala
@@ -24,11 +24,11 @@ class FormalCoverSpec extends AnyFreeSpec with Matchers {
       tester.step(10)
 
       val c1 = tester.getCoverage().toMap
-      assert(c1("cover0") == 5)
-      assert(c1("cover1") == 3)
-      assert(c1("cover2") == 2)
-      assert(c1("cover3") == 1)
-      assert(c1("c.cover0") + c1("c.cover1") == 10)
+      assert(c1("cover_0") == 5)
+      assert(c1("cover_1") == 3)
+      assert(c1("cover_2") == 2)
+      assert(c1("cover_3") == 1)
+      assert(c1("c.cov0") + c1("c.cov1_this_is_custom") == 10)
     }
   }
 

--- a/src/test/scala/treadle/VerificationSpec.scala
+++ b/src/test/scala/treadle/VerificationSpec.scala
@@ -55,12 +55,11 @@ class VerificationSpec extends AnyFreeSpec with Matchers {
       Console.withOut(new PrintStream(output)) {
         TreadleTestHarness(Seq(FirrtlSourceAnnotation(input(doAssume = true)), ShowFirrtlAtLoadAnnotation)) { _ => }
       }
-      output.toString should not include ("assume")
-      output.toString should include(
-        """    printf(clock, and(not(lt(io_in, UInt<8>("h7f"))), UInt<1>("h1")), "input was not less that 0x7f")
-          |    stop(clock, and(not(lt(io_in, UInt<8>("h7f"))), UInt<1>("h1")), 66)
-          |""".stripMargin
-      )
+      output.toString should not include ("assume(")
+      output.toString should include (
+      """printf(clock, and(not(lt(io_in, UInt<8>("h7f"))), UInt<1>("h1")), "input was not less that 0x7f")""")
+      output.toString should include (
+      """stop(clock, and(not(lt(io_in, UInt<8>("h7f"))), UInt<1>("h1")), 66)""")
     }
 
     "but IgnoreFormalAssumesAnnotation will drop assume statements" in {
@@ -72,10 +71,9 @@ class VerificationSpec extends AnyFreeSpec with Matchers {
       }
       output.toString should not include ("assume")
       output.toString should not include (
-        """    printf(clock, and(not(lt(io_in, UInt<8>("h7f"))), UInt<1>("h1")), "input was not less that 0x7f")
-          |    stop(clock, and(not(lt(io_in, UInt<8>("h7f"))), UInt<1>("h1")), 66)
-          |""".stripMargin
-        )
+        """printf(clock, and(not(lt(io_in, UInt<8>("h7f"))), UInt<1>("h1")), "input was not less that 0x7f")""")
+      output.toString should not include (
+        """stop(clock, and(not(lt(io_in, UInt<8>("h7f"))), UInt<1>("h1")), 66)""")
     }
 
     def runStopTest(firrtlString: String): Unit = {


### PR DESCRIPTION
This PR makes `treadle` use the (optional) names of `printf`, `stop` and cover statements as their symbol name instead of auto-generating a name.
Statements that do not have a name (since the name is optional) are automatically named through the `EnsureNamedStatements` pass from firrtl.