### PR TITLE
build: remove explicit dependencies on scopt and json libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,9 +42,7 @@ lazy val baseSettings = Seq(
   libraryDependencies ++= Seq(
     "junit" % "junit" % "4.13" % "test",
     "org.scalatest" %% "scalatest" % "3.2.4" % "test",
-    "com.github.scopt" %% "scopt" % "3.7.1",
     "org.scala-lang.modules" % "scala-jline" % "2.12.1",
-    "org.json4s" %% "json4s-native" % "3.6.10"
   ),
   scalacOptions in Compile ++= Seq(
     "-deprecation",

--- a/build.sc
+++ b/build.sc
@@ -83,9 +83,7 @@ class treadleCrossModule(crossVersionValue: String) extends CommonModule with Pu
   def mainClass = Some("treadle.repl.TreadleReplMain")
 
   def ivyDeps = super.ivyDeps() ++ Agg(
-    ivy"com.github.scopt::scopt:3.7.1",
     ivy"org.scala-lang.modules:scala-jline:2.12.1",
-    ivy"org.json4s::json4s-native:3.6.10"
   )
 
   object test extends Tests {


### PR DESCRIPTION
These are pulled in via firrtl anyways and specifying
them explicitly just leads to potential version conflicts.