### PR TITLE
cover: fix aliasing of submodule cover statements

### DIFF
--- a/src/main/scala/treadle/executable/ExpressionCompiler.scala
+++ b/src/main/scala/treadle/executable/ExpressionCompiler.scala
@@ -953,7 +953,8 @@ class ExpressionCompiler(
         }
 
       case verify @ Verification(Formal.Cover, info, clockExpression, predicateExpression, enableExpression, message) =>
-        symbolTable.verifyToVerifyInfo.get(verify) match {
+        val name = expand(verify.name)
+        symbolTable.verifyInfo.get(name) match {
           case Some(verifyInfo) =>
             val intEnableExpression =
               toIntExpression(enableExpression, s"Error: verify $verify has unknown enable type")

--- a/src/main/scala/treadle/executable/ExpressionViewBuilder.scala
+++ b/src/main/scala/treadle/executable/ExpressionViewBuilder.scala
@@ -311,7 +311,8 @@ class ExpressionViewBuilder(
               enableExpression,
               message
             ) =>
-          expressionViews(symbolTable.verifyToVerifyInfo(verify).verifySymbol) = processExpression(predicateExpression)
+          val expandedName = expand(verify.name)
+          expressionViews(symbolTable.verifyInfo(expandedName).verifySymbol) = processExpression(predicateExpression)
 
         case EmptyStmt =>
         case conditionally: Conditionally =>

--- a/src/main/scala/treadle/executable/SymbolTable.scala
+++ b/src/main/scala/treadle/executable/SymbolTable.scala
@@ -48,10 +48,10 @@ class SymbolTable(val nameToSymbol: mutable.HashMap[String, Symbol]) {
 
   val moduleMemoryToMemorySymbol: mutable.HashMap[String, mutable.HashSet[Symbol]] = new mutable.HashMap
 
-  val stopToStopInfo:     mutable.HashMap[Stop, StopInfo] = new mutable.HashMap[Stop, StopInfo]
-  val printToPrintInfo:   mutable.HashMap[Print, PrintInfo] = new mutable.HashMap[Print, PrintInfo]
-  val verifyToVerifyInfo: mutable.HashMap[Verification, VerifyInfo] = new mutable.HashMap[Verification, VerifyInfo]
-  val verifyOps:          mutable.ListBuffer[VerifyOp] = new mutable.ListBuffer[VerifyOp]
+  val stopToStopInfo:   mutable.HashMap[Stop, StopInfo] = new mutable.HashMap[Stop, StopInfo]
+  val printToPrintInfo: mutable.HashMap[Print, PrintInfo] = new mutable.HashMap[Print, PrintInfo]
+  val verifyInfo:       mutable.HashMap[String, VerifyInfo] = new mutable.HashMap[String, VerifyInfo]
+  val verifyOps:        mutable.ListBuffer[VerifyOp] = new mutable.ListBuffer[VerifyOp]
 
   def isRegister(name:      String): Boolean = registerNames.contains(name)
   def isTopLevelInput(name: String): Boolean = inputPortsNames.contains(name)
@@ -199,7 +199,7 @@ object SymbolTable extends LazyLogging {
     var printfCardinal: Int = 0
     val lastPrintfInModule = new mutable.HashMap[Module, Symbol]
 
-    val verifyToVerifyInfo = new mutable.HashMap[Verification, VerifyInfo]
+    val verifyInfo = new mutable.HashMap[String, VerifyInfo]
     var verifyCardinal: Int = 0
     val lastVerifyInModule = new mutable.HashMap[Module, Symbol]
 
@@ -459,7 +459,7 @@ object SymbolTable extends LazyLogging {
               addSymbol(verifySymbol)
 
               verifyCardinal += 1
-              verifyToVerifyInfo(verify) = VerifyInfo(verifySymbol, verifyCardinal)
+              verifyInfo(verifySymbolName) = VerifyInfo(verifySymbol, verifyCardinal)
               addDependency(verifySymbol, expressionToReferences(clockExpression))
               addDependency(verifySymbol, expressionToReferences(enableExpression))
               addDependency(verifySymbol, expressionToReferences(predicateExpression))
@@ -631,7 +631,7 @@ object SymbolTable extends LazyLogging {
     symbolTable.registerToClock ++= registerToClock
     symbolTable.stopToStopInfo ++= stopToStopInfo
     symbolTable.printToPrintInfo ++= printToPrintInfo
-    symbolTable.verifyToVerifyInfo ++= verifyToVerifyInfo
+    symbolTable.verifyInfo ++= verifyInfo
 
     symbolTable.parentsOf = sensitivityGraphBuilder.getParentsOfDiGraph
     symbolTable.childrenOf = sensitivityGraphBuilder.getChildrenOfDiGraph

--- a/src/test/resources/CoverageTestModule.fir
+++ b/src/test/resources/CoverageTestModule.fir
@@ -1,0 +1,40 @@
+; from a chiseltest test
+; we expect to see two distince coverage count for the two instances of SubModule1:
+; c0.cover_0 and c1.cover_0
+circuit CoverageTestModule :
+  module SubModule1 :
+    input clock : Clock
+    input reset : UInt<1>
+    input a : UInt<3>
+
+    node _T = gt(a, UInt<3>("h4")) @[Test1Module.scala 45:45]
+    cover(clock, _T, UInt<1>("h1"), "user coverage 2") @[Test1Module.scala 45:42]
+
+  module CoverageTestModule :
+    input clock : Clock
+    input reset : UInt<1>
+    input a : UInt<3>
+    output b : UInt<3>
+
+    inst c0 of SubModule1 @[Test1Module.scala 36:20]
+    inst c1 of SubModule1 @[Test1Module.scala 38:20]
+    node _T = eq(a, UInt<3>("h4")) @[Test1Module.scala 13:10]
+    node _GEN_0 = mux(_T, UInt<1>("h1"), UInt<1>("h0")) @[Test1Module.scala 13:19 Test1Module.scala 14:7 Test1Module.scala 11:5]
+    node _T_1 = lt(UInt<3>("h5"), a) @[Test1Module.scala 17:12]
+    node _GEN_1 = mux(_T_1, UInt<2>("h2"), UInt<2>("h3")) @[Test1Module.scala 17:17 Test1Module.scala 18:7 Test1Module.scala 20:7]
+    node _T_2 = eq(a, UInt<1>("h0")) @[Test1Module.scala 23:10]
+    node _T_3 = eq(a, UInt<1>("h1")) @[Test1Module.scala 27:10]
+    reg cover_chain_en : UInt<3>, clock with :
+      reset => (UInt<1>("h0"), cover_chain_en) @[Test1Module.scala 32:31]
+    ; changed (a - 4) to (a + 5) such that the cover statement inside c1 becomes true when a=0
+    node _c1_a_T = add(a, UInt<3>("h5")) @[Test1Module.scala 39:15]
+    node _c1_a_T_1 = tail(_c1_a_T, 1) @[Test1Module.scala 39:15]
+    b <= _GEN_1
+    cover_chain_en <= mux(reset, UInt<3>("h0"), a) @[Test1Module.scala 32:31 Test1Module.scala 32:31 Test1Module.scala 33:18]
+    c0.clock <= clock
+    c0.reset <= reset
+    c0.a <= a @[Test1Module.scala 37:10]
+    c1.clock <= clock
+    c1.reset <= reset
+    c1.a <= _c1_a_T_1 @[Test1Module.scala 39:10]
+    cover(clock, UInt<1>("h1"), and(and(UInt<1>("h1"), _T_2), UInt<1>("h1")), "user coverage") @[Test1Module.scala 24:44]


### PR DESCRIPTION
Previously the `symbolTable.verifyToVerifyInfo` HashMap would map a firrtl cover statement to its treadle Symbol.
However, since a module can be instantiated more than once, this lead to aliasing problems.
We now use the unique symbol name to index into this hash table.