### PR TITLE
Fix chisel3 import in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The easiest way to invoke the interpreter is through a test based harness. The I
 ClassicTester, it's api consists of poke, peek and expect statements. Here is an example of a GCD Circuit
 
 ```scala
-import chisel._
+import chisel3._
 import treadle.TreadleTester
 import org.scalatest.{Matchers, FlatSpec}
 


### PR DESCRIPTION
`import chisel._` led to `not found: object chisel` error