### PR TITLE
Backport pr322

### DIFF
--- a/src/main/scala/treadle/executable/IntOps.scala
+++ b/src/main/scala/treadle/executable/IntOps.scala
@@ -138,7 +138,11 @@ case class DshlInts(f1: FuncInt, f2: FuncInt) extends IntExpressionResult {
 }
 
 case class DshrInts(f1: FuncInt, f2: FuncInt) extends IntExpressionResult {
-  def apply(): Int = f1() >> f2()
+  def apply(): Int = {
+    val v1 = f1()
+    val v2 = f2()
+    if (v2 > 31) 0 else v1 >> v2
+  }
 }
 
 case class NegInts(f1: FuncInt) extends IntExpressionResult {

--- a/src/main/scala/treadle/executable/LongPrimOps.scala
+++ b/src/main/scala/treadle/executable/LongPrimOps.scala
@@ -116,7 +116,7 @@ case class DshrLongs(f1: FuncLong, f2: FuncLong) extends LongExpressionResult {
   def apply(): Long = {
     val a: Long = f1()
     val b: Long = f2()
-    a >> b.toInt
+    if (b > 63) 0 else a >> b.toInt
   }
 }
 

--- a/src/test/scala/treadle/PrintStopSpec.scala
+++ b/src/test/scala/treadle/PrintStopSpec.scala
@@ -481,7 +481,7 @@ class PrintStopSpec extends AnyFlatSpec with Matchers with LazyLogging {
         |    input reset : UInt<1>
         |    output io : {flip in : UInt<10>, out : UInt<10>}
         |
-        |    node T1 = io.in
+        |    node T1 = eq(io.in, UInt<1>(1))
         |    node T2 = eq(T1, UInt<1>(1))
         |    node T3 = eq(T2, UInt<1>(1))
         |    node T4 = eq(T3, UInt<1>(1))

--- a/src/test/scala/treadle/primops/ShlShrDshlDshr.scala
+++ b/src/test/scala/treadle/primops/ShlShrDshlDshr.scala
@@ -8,7 +8,18 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import treadle.executable._
 import treadle.utils.Render
+<<<<<<< HEAD
 import treadle.{BitTwiddlingUtils, TreadleTestHarness, extremaOfSIntOfWidth, extremaOfUIntOfWidth}
+=======
+import treadle.{
+  extremaOfSIntOfWidth,
+  extremaOfUIntOfWidth,
+  BitTwiddlingUtils,
+  IntWidthTestValuesGenerator,
+  TestUtils,
+  TreadleTestHarness
+}
+>>>>>>> 8dc6b63... Fixes DSHR shift problem (#322)
 
 // scalastyle:off magic.number
 class ShlShrDshlDshr extends AnyFreeSpec with Matchers with LazyLogging {
@@ -22,7 +33,7 @@ class ShlShrDshlDshr extends AnyFreeSpec with Matchers with LazyLogging {
         j <- 0 to bitWidth * 2
       } {
         val a = i.toInt
-        val b = j.toInt
+        val b = j
         val staticShifter = ShlInts(() => a, () => b).apply _
         val dynamicShifter = DshlInts(() => a, () => b).apply _
         val staticExpected = BitTwiddlingUtils.shl(a, b).toInt
@@ -88,7 +99,7 @@ class ShlShrDshlDshr extends AnyFreeSpec with Matchers with LazyLogging {
         j <- 0 to bitWidth * 2
       } {
         val a = i.toInt
-        val b = j.toInt
+        val b = j
         val staticShifter = ShlInts(() => a, () => b).apply _
         val dynamicShifter = DshlInts(() => a, () => b).apply _
         val staticExpected = BitTwiddlingUtils.shl(a, b).toInt
@@ -112,7 +123,7 @@ class ShlShrDshlDshr extends AnyFreeSpec with Matchers with LazyLogging {
         j <- 0 to bitWidth * 2
       } {
         val a = i.toInt
-        val b = j.toInt
+        val b = j
         val staticShifter = ShrInts(() => a, () => b).apply _
         val dynamicShifter = DshrInts(() => a, () => b).apply _
         val staticExpected = BitTwiddlingUtils.shr(a, b).toInt
@@ -134,7 +145,7 @@ class ShlShrDshlDshr extends AnyFreeSpec with Matchers with LazyLogging {
         j <- 0 to bitWidth * 2
       } {
         val a = i.toInt
-        val b = j.toInt
+        val b = j
         val staticShifter = ShrInts(() => a, () => b).apply _
         val dynamicShifter = DshrInts(() => a, () => b).apply _
         val staticExpected = BitTwiddlingUtils.shr(a, b).toInt
@@ -145,6 +156,37 @@ class ShlShrDshlDshr extends AnyFreeSpec with Matchers with LazyLogging {
 
         staticShifter() should be(staticExpected)
         dynamicShifter() should be(staticExpected)
+      }
+    }
+  }
+
+  "Dshr should work for pathological edge cases" in {
+    def dshrIntFirrtl(width: Int): String = {
+      s"""
+         |;buildInfoPackage: chisel3, version: 3.5-SNAPSHOT, scalaVersion: 2.12.13, sbtVersion: 1.3.10
+         |circuit ShiftTestInt :
+         |  module ShiftTestInt :
+         |    input clock : Clock
+         |    input reset : UInt<1>
+         |    input a : UInt<$width>
+         |    input b : UInt<30>
+         |    output dshrOut : UInt<$width>
+         |
+         |    node _T = dshr(a, b) @[TreadleDshrTest.scala 15:16]
+         |    dshrOut <= _T @[TreadleDshrTest.scala 15:11]
+         |
+         |""".stripMargin
+    }
+
+    for (width <- new IntWidthTestValuesGenerator(1, 70)) {
+      TreadleTestHarness(Seq(FirrtlSourceAnnotation(dshrIntFirrtl(width)))) { tester =>
+        tester.poke("a", 1)
+
+        for (i <- 1 until 70) {
+          tester.poke("b", i)
+          tester.step()
+          tester.expect("dshrOut", BigInt(0))
+        }
       }
     }
   }

--- a/src/test/scala/treadle/primops/ShlShrDshlDshr.scala
+++ b/src/test/scala/treadle/primops/ShlShrDshlDshr.scala
@@ -8,18 +8,13 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import treadle.executable._
 import treadle.utils.Render
-<<<<<<< HEAD
-import treadle.{BitTwiddlingUtils, TreadleTestHarness, extremaOfSIntOfWidth, extremaOfUIntOfWidth}
-=======
 import treadle.{
   extremaOfSIntOfWidth,
   extremaOfUIntOfWidth,
   BitTwiddlingUtils,
   IntWidthTestValuesGenerator,
-  TestUtils,
   TreadleTestHarness
 }
->>>>>>> 8dc6b63... Fixes DSHR shift problem (#322)
 
 // scalastyle:off magic.number
 class ShlShrDshlDshr extends AnyFreeSpec with Matchers with LazyLogging {


### PR DESCRIPTION
This is an manual backport of pull request #322
When:
Shifting Int wire by 32 or 64
Shifting Long wire by 64
Both cases now return correct zero value
Also contains fix of PrintStopSpec passing multi-bit enable to stop