### PR TITLE
expectMemory now shows index when error occurs

### DIFF
--- a/src/main/scala/treadle/TreadleTester.scala
+++ b/src/main/scala/treadle/TreadleTester.scala
@@ -365,7 +365,7 @@ class TreadleTester(annotationSeq: AnnotationSeq) {
     if (value != expectedValue) {
       val renderer = new ExpressionViewRenderer(engine.dataStore, engine.symbolTable, engine.expressionViews)
       val calculation = renderer.render(engine.symbolTable(name), wallTime.currentTime)
-      fail(TreadleException(s"Error:expect($name, $expectedValue) got $value $message\n$calculation"))
+      fail(TreadleException(s"Error:expect($name($index), $expectedValue) got $value $message\n$calculation"))
     }
     expectationsMet += 1
   }

--- a/src/test/scala/treadle/MemoryUsageSpec.scala
+++ b/src/test/scala/treadle/MemoryUsageSpec.scala
@@ -3,14 +3,13 @@
 package treadle
 
 import java.io.{File, PrintWriter}
-
 import firrtl.FileUtils
 import firrtl.annotations.{CircuitName, ComponentName, LoadMemoryAnnotation, ModuleName}
 import firrtl.stage.FirrtlSourceAnnotation
 import logger.LazyLogging
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
-import treadle.executable.StopException
+import treadle.executable.{StopException, TreadleException}
 
 /** Created by chick on 4/30/16.
   */
@@ -567,4 +566,43 @@ class MemoryUsageSpec extends AnyFreeSpec with Matchers with LazyLogging {
       }
     }
   }
+
+  "memory expect errors should include index in error" in {
+    val input =
+      """circuit Test :
+        |  module Test :
+        |    input clock    : Clock
+        |    input in1      : UInt<8>
+        |    input addr     : UInt<8>
+        |    input write_en : UInt<1>
+        |    output out1    : UInt<8>
+        |    mem m :
+        |      data-type => UInt<8>
+        |      depth => 32
+        |      read-latency => 0
+        |      write-latency => 1
+        |      reader => read
+        |      writer => write
+        |
+        |    m.read.clk <= clock
+        |    m.read.en <= eq(write_en, UInt<1>(0))
+        |    m.read.addr <= addr
+        |
+        |    m.write.clk <= clock
+        |    m.write.en <= eq(write_en, UInt<1>(1))
+        |    m.write.mask <= UInt<8>("hff")
+        |    m.write.addr <= addr
+        |    m.write.data <= in1
+        |
+        |    out1 <= m.read.data
+      """.stripMargin
+
+    val e = intercept[TreadleException] {
+      TreadleTestHarness(Seq(FirrtlSourceAnnotation(input))) { tester =>
+        tester.expectMemory("m", 11, 17)
+      }
+    }
+    e.getMessage should include("Error:expect(m(11), 17) got 0")
+  }
+
 }


### PR DESCRIPTION
Helpful to see what memory index was being called when a failure occurs
Addresses Issue #232 