### PR TITLE
remove testOnly, since upstream implemented it.

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -96,10 +96,6 @@ class treadleCrossModule(crossVersionValue: String) extends CommonModule with Pu
     ) ++ ivyCrossDeps
 
     def testFrameworks = Seq("org.scalatest.tools.Framework")
-
-    def testOnly(args: String*) = T.command {
-      super.runMain("org.scalatest.run", args: _*)
-    }
   }
 
   override def buildInfoPackageName = Some("treadle")


### PR DESCRIPTION
Mill implemented its own `testOnly` in https://github.com/com-lihaoyi/mill/commit/838e3259921718778b01b554455bbf1942865cb5 , this PR fixed compile in mill 0.9.8.