### PR TITLE
Cleans up `Stop` handling in Treadle

### DIFF
--- a/src/main/scala/treadle/TreadleTester.scala
+++ b/src/main/scala/treadle/TreadleTester.scala
@@ -316,7 +316,7 @@ class TreadleTester(annotationSeq: AnnotationSeq) {
     if (lineValidators.isEmpty) initLineValidators()
 
     //Keep track of coverage
-    lineValidators = lineValidators.zip(Coverage.getValidators(engine.ast, this)).map(v => v._1.toInt | v._2.toInt)
+    lineValidators = lineValidators.zip(Coverage.getValidators(engine.ast, this)).map(v => v._1 | v._2)
   }
 
   def cycleCount: Long = clockStepper.cycleCount
@@ -410,7 +410,11 @@ class TreadleTester(annotationSeq: AnnotationSeq) {
   def isRegister(symbolName: String): Boolean = engine.symbolTable.isRegister(symbolName)
 
   def getStopResult: Option[Int] = {
-    engine.lastStopResult
+    engine.lastStopException match {
+      case Some(stopException: StopException) =>
+        Some(stopException.stopValue)
+      case _ => None
+    }
   }
 
   def reportString: String = {
@@ -423,11 +427,9 @@ class TreadleTester(annotationSeq: AnnotationSeq) {
         see this report which should include the Failed in that case
      */
     def status: String = {
-      engine.lastStopResult match {
-        case Some(0) =>
-          s"Stopped: Stop result 0:"
-        case Some(stopResult) =>
-          s"Failed: Stop result $stopResult:"
+      engine.lastStopException match {
+        case Some(stopException: StopException) =>
+          stopException.getMessage
         case _ =>
           if (isOK) {
             s"Success:"

--- a/src/main/scala/treadle/executable/ExpressionCompiler.scala
+++ b/src/main/scala/treadle/executable/ExpressionCompiler.scala
@@ -923,7 +923,10 @@ class ExpressionCompiler(
         Memory.buildMemoryInternals(defMemory, expandedName, scheduler, compiler = this)
 
       case _: IsInvalid =>
+
       case stop @ Stop(info, returnValue, clockExpression, enableExpression) =>
+        val stopSymbolName = expand(stop.name)
+
         symbolTable.stopToStopInfo.get(stop) match {
           case Some(stopInfo) =>
             val intExpression = toIntExpression(enableExpression, s"Error: stop $stop has unknown condition type")
@@ -940,7 +943,9 @@ class ExpressionCompiler(
                   condition = intExpression,
                   hasStopped = symbolTable(StopOp.stopHappenedName),
                   dataStore = dataStore,
-                  clockTransitionGetter
+                  clockTransitionGetter,
+                  stopSymbolName,
+                  Some(scheduler)
                 )
                 addAssigner(stopOp)
               case _ =>

--- a/src/main/scala/treadle/executable/StopOp.scala
+++ b/src/main/scala/treadle/executable/StopOp.scala
@@ -11,7 +11,9 @@ case class StopOp(
   condition:       IntExpressionResult,
   hasStopped:      Symbol,
   dataStore:       DataStore,
-  clockTransition: ClockTransitionGetter)
+  clockTransition: ClockTransitionGetter,
+  stopName:        String,
+  schedulerOpt:    Option[Scheduler])
     extends Assigner {
 
   def run: FuncUnit = {
@@ -26,6 +28,12 @@ case class StopOp(
           println(s"stop ${symbol.name} has fired")
         }
         dataStore(hasStopped) = returnValue + 1
+        val stopException = StopException(returnValue, stopName, info)
+        schedulerOpt.foreach { scheduler =>
+          scheduler.executionEngineOpt.foreach { engine =>
+            engine.lastStopException = Some(stopException)
+          }
+        }
       }
     }
 

--- a/src/main/scala/treadle/executable/TreadleException.scala
+++ b/src/main/scala/treadle/executable/TreadleException.scala
@@ -2,8 +2,26 @@
 
 package treadle.executable
 
+import firrtl.ir._
+
 /** Created by chick on 4/21/16.
   */
 case class TreadleException(message: String) extends Exception(message)
 
-case class StopException(message: String) extends Exception(message)
+case class StopException(
+  stopValue: Int,
+  stopName:  String,
+  stopInfo:  Info)
+    extends Exception {
+  override def getMessage: String = {
+    val state = if (stopValue == 0) { s"Stopped" }
+    else { "Failure Stop" }
+    val where = stopInfo match {
+      case NoInfo => ""
+      case info   => s" at $info"
+    }
+    s"$state:$stopName:($stopValue)$where"
+  }
+
+  def message: String = getMessage
+}

--- a/src/test/scala/treadle/PrintStopSpec.scala
+++ b/src/test/scala/treadle/PrintStopSpec.scala
@@ -508,7 +508,6 @@ class PrintStopSpec extends AnyFlatSpec with Matchers with LazyLogging {
 
     val printfLines = output.toString.split("\n").filter(_.startsWith("+++"))
 
-    println(output.toString)
     for {
       i <- 0 until 2
       j <- 0 until 4

--- a/src/test/scala/treadle/VerificationSpec.scala
+++ b/src/test/scala/treadle/VerificationSpec.scala
@@ -11,7 +11,7 @@ import treadle.executable.StopException
 import treadle.stage.phases.IgnoreFormalAssumesAnnotation
 
 class VerificationSpec extends AnyFreeSpec with Matchers {
-  def input(doAssume: Boolean = false) = {
+  def input(doAssume: Boolean = false): String = {
     val inject = if (doAssume) {
       "assume"
     } else {
@@ -108,7 +108,8 @@ class VerificationSpec extends AnyFreeSpec with Matchers {
         val result = intercept[StopException] {
           runStopTest(input())
         }
-        result.message should include("Failure Stop: result 65")
+        result.stopValue should be(65)
+        result.message should include("Failure Stop:assert_0:(65)")
       }
       output.toString should include("input was not less that 0x7f")
     }
@@ -119,7 +120,8 @@ class VerificationSpec extends AnyFreeSpec with Matchers {
         val result = intercept[StopException] {
           runStopTest(input(doAssume = true))
         }
-        result.message should include("Failure Stop: result 66")
+        result.stopValue should be(66)
+        result.message should include("Failure Stop:assume_0:(66)")
       }
       output.toString should include("input was not less that 0x7f")
     }


### PR DESCRIPTION
- When stop happens during circuit evaluation
  - Create and `StopException`
  - Save it in the engine
  - At end of circuit evaluation
    - Check for saved `StopException`
    - Throw it
- Create richer `StopException`
  - Includes `stopValue`, `stopName`, `info`
  - These can be used for richer analysis and reporting
- Fix up some tests
- Fix up randomization implementation
  - Exposed by problem when running `RandomizeCircuitTest`