### PR TITLE
Added coverage count test

### DIFF
--- a/src/test/resources/ToggleCoverage.fir
+++ b/src/test/resources/ToggleCoverage.fir
@@ -1,0 +1,21 @@
+circuit test :
+  module test :
+    input metaReset : UInt<1>
+    input clock : Clock
+    input reset : UInt<1>
+    input cond : UInt<1>
+    output out : UInt<32>
+    output assert_failed : UInt<1>
+
+    node _GEN_0 = mux(cond, UInt<4>("h8"), UInt<3>("h7"))
+    out <= _GEN_0
+    reg prev_reset : UInt<1>, clock with :
+      reset => (UInt<1>("h0"), prev_reset)
+    prev_reset <= mux(metaReset, UInt<1>("h0"), reset)
+    node cond_s = cond
+    reg cond_prev : UInt<1>, clock with :
+      reset => (UInt<1>("h0"), cond_prev)
+    cond_prev <= mux(metaReset, UInt<1>("h0"), cond_s)
+    node cond_toggle = xor(cond_s, cond_prev)
+    cover(clock, cond_toggle, not(or(reset, prev_reset)), "") : cond_toggleNoReset
+    assert_failed <= UInt<1>("h0")

--- a/src/test/scala/treadle/CoverageIssue.scala
+++ b/src/test/scala/treadle/CoverageIssue.scala
@@ -1,0 +1,27 @@
+package treadle
+
+import firrtl.stage.FirrtlSourceAnnotation
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class CoverageIssue extends AnyFreeSpec with Matchers {
+
+  "coverage should be counted properly" in {
+    val stream = getClass.getResourceAsStream("/ToggleCoverage.fir")
+    val firrtlSource = scala.io.Source.fromInputStream(stream).getLines().mkString("\n")
+    TreadleTestHarness(Seq(FirrtlSourceAnnotation(firrtlSource))) { tester =>
+      //Defines the signals which poked and expected on each clock cycle
+      val signal_values = List((1, 1, 0), (0, 0, 0), (0, 1, 1), (0, 0, 2), (0, 0, 2), (0, 1, 3), (0, 1, 3), (0, 0, 4))
+      signal_values.foreach { case (reset, cond, cov) =>
+        tester.poke("reset", reset)
+        tester.poke("cond", cond)
+        tester.step()
+
+        println(tester.getCoverage())
+        assert(tester.getCoverage().head._2 == cov)
+      }
+
+    }
+  }
+
+}


### PR DESCRIPTION
This new test on coverage counts fails.
Coverage counts are expected to increase over time. Instead, they stay at 0 for all cycles.

This test passes when using VerilatorSimulator.