### PR TITLE
Fix verification register handling

### DIFF
--- a/src/main/scala/treadle/executable/Transition.scala
+++ b/src/main/scala/treadle/executable/Transition.scala
@@ -54,7 +54,8 @@ case class ClockBasedAssigner(
     } else if (isVerbose) {
       println(
         s"${assigner.symbol.name} <= register not updated" +
-          s" ${clockSymbol.name} state ${clockTransitionGetter.transition} not the required $requiredTransition"
+          s" ${clockSymbol.name} state ${clockTransitionGetter.transition} not the required $requiredTransition" +
+          s" (currently ${dataStore(assigner.symbol)})"
       )
     }
   }

--- a/src/test/resources/ToggleCoverage.fir
+++ b/src/test/resources/ToggleCoverage.fir
@@ -17,5 +17,7 @@ circuit test :
       reset => (UInt<1>("h0"), cond_prev)
     cond_prev <= mux(metaReset, UInt<1>("h0"), cond_s)
     node cond_toggle = xor(cond_s, cond_prev)
-    cover(clock, cond_toggle, not(or(reset, prev_reset)), "") : cond_toggleNoReset
+    node cover_enable = not(or(reset, prev_reset))
+    printf(clock, UInt<1>("h1"), "CoverConditions: cond_toggle %d cover_enable %d\n", cond_toggle, cover_enable)
+    cover(clock, cond_toggle, cover_enable, "") : cond_toggleNoReset
     assert_failed <= UInt<1>("h0")

--- a/src/test/resources/ToggleCoverage.fir
+++ b/src/test/resources/ToggleCoverage.fir
@@ -1,0 +1,21 @@
+circuit test :
+  module test :
+    input metaReset : UInt<1>
+    input clock : Clock
+    input reset : UInt<1>
+    input cond : UInt<1>
+    output out : UInt<32>
+    output assert_failed : UInt<1>
+
+    node _GEN_0 = mux(cond, UInt<4>("h8"), UInt<3>("h7"))
+    out <= _GEN_0
+    reg prev_reset : UInt<1>, clock with :
+      reset => (UInt<1>("h0"), prev_reset)
+    prev_reset <= mux(metaReset, UInt<1>("h0"), reset)
+    node cond_s = cond
+    reg cond_prev : UInt<1>, clock with :
+      reset => (UInt<1>("h0"), cond_prev)
+    cond_prev <= mux(metaReset, UInt<1>("h0"), cond_s)
+    node cond_toggle = xor(cond_s, cond_prev)
+    cover(clock, cond_toggle, not(or(reset, prev_reset)), "") : cond_toggleNoReset
+    assert_failed <= UInt<1>("h0")

--- a/src/test/scala/treadle/CoverageIssue.scala
+++ b/src/test/scala/treadle/CoverageIssue.scala
@@ -1,0 +1,27 @@
+package treadle
+
+import firrtl.stage.FirrtlSourceAnnotation
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class CoverageIssue extends AnyFreeSpec with Matchers {
+
+  "coverage should be counted properly" in {
+    val stream = getClass.getResourceAsStream("/ToggleCoverage.fir")
+    val firrtlSource = scala.io.Source.fromInputStream(stream).getLines().mkString("\n")
+    TreadleTestHarness(Seq(FirrtlSourceAnnotation(firrtlSource))) { tester =>
+      //Defines the signals which poked and expected on each clock cycle
+      val signal_values = List((1, 1, 0), (0, 0, 0), (0, 1, 1), (0, 0, 2), (0, 0, 2), (0, 1, 3), (0, 1, 3), (0, 0, 4))
+      signal_values.foreach { case (reset, cond, cov) =>
+        tester.poke("reset", reset)
+        tester.poke("cond", cond)
+        tester.step()
+
+        println(tester.getCoverage())
+        assert(tester.getCoverage().head._2 == cov)
+      }
+
+    }
+  }
+
+}

--- a/src/test/scala/treadle/FormalCoverSpec.scala
+++ b/src/test/scala/treadle/FormalCoverSpec.scala
@@ -25,8 +25,8 @@ class FormalCoverSpec extends AnyFreeSpec with Matchers {
 
       val c1 = tester.getCoverage().toMap
       assert(c1("cover_0") == 5)
-      assert(c1("cover_1") == 3)
-      assert(c1("cover_2") == 2)
+      assert(c1("cover_1") == 2)
+      assert(c1("cover_2") == 1)
       assert(c1("cover_3") == 1)
       assert(c1("c.cov0") + c1("c.cov1_this_is_custom") == 10)
     }
@@ -59,8 +59,8 @@ class FormalCoverSpec extends AnyFreeSpec with Matchers {
 
       val c1 = tester.getCoverage().toMap
       assert(c1("cover_0") == 5)
-      assert(c1("cover_1") == 3)
-      assert(c1("cover_2") == 2)
+      assert(c1("cover_1") == 2)
+      assert(c1("cover_2") == 1)
       assert(c1("cover_3") == 1)
       assert(c1("c.cov0") + c1("c.cov1_this_is_custom") == 10)
 
@@ -93,8 +93,8 @@ class FormalCoverSpec extends AnyFreeSpec with Matchers {
       ""","cov0",10,2""",
       ""","cov1",10,8""",
       """@[VerificationSpec.scala 42:19],"register 0 cover",10,5""",
-      """@[VerificationSpec.scala 52:19],"register 1 cover",5,3""",
-      """@[VerificationSpec.scala 62:19],"register 2 cover",3,2""",
+      """@[VerificationSpec.scala 52:19],"register 1 cover",5,2""",
+      """@[VerificationSpec.scala 62:19],"register 2 cover",3,1""",
       """@[VerificationSpec.scala 72:19],"register 3 cover",2,1"""
     )
     lines.zip(expectedLines).foreach { case (a, b) =>
@@ -130,8 +130,8 @@ class FormalCoverSpec extends AnyFreeSpec with Matchers {
 
     val expectedLines = Seq(
       """cover(clock, out_reg, UInt<1>("h1"), "register 0 cover")  @[VerificationSpec.scala 42:19]   COV(10,5)""",
-      """cover(_out_T, out_reg_1, UInt<1>("h1"), "register 1 cover")  @[VerificationSpec.scala 52:19]   COV(5,3)""",
-      """cover(_out_T_1, out_reg_2, UInt<1>("h1"), "register 2 cover")  @[VerificationSpec.scala 62:19]   COV(3,2)""",
+      """cover(_out_T, out_reg_1, UInt<1>("h1"), "register 1 cover")  @[VerificationSpec.scala 52:19]   COV(5,2)""",
+      """cover(_out_T_1, out_reg_2, UInt<1>("h1"), "register 2 cover")  @[VerificationSpec.scala 62:19]   COV(3,1)""",
       """cover(_out_T_2, out_reg_3, UInt<1>("h1"), "register 3 cover")  @[VerificationSpec.scala 72:19]   COV(2,1)"""
     )
     expectedLines.foreach { expectedLine =>

--- a/src/test/scala/treadle/VerificationSpec.scala
+++ b/src/test/scala/treadle/VerificationSpec.scala
@@ -57,9 +57,9 @@ class VerificationSpec extends AnyFreeSpec with Matchers {
       }
       (output.toString should not).include("assume(")
       output.toString should include(
-        """printf(clock, and(not(lt(io_in, UInt<8>("h7f"))), UInt<1>("h1")), "input was not less that 0x7f")"""
+        """printf(_GEN_7, and(not(_GEN_8), _GEN_5), "input was not less that 0x7f")"""
       )
-      output.toString should include("""stop(clock, and(not(lt(io_in, UInt<8>("h7f"))), UInt<1>("h1")), 66)""")
+      output.toString should include("""stop(_GEN_7, and(not(_GEN_8), _GEN_5), 66) : assume_0""")
     }
 
     "but IgnoreFormalAssumesAnnotation will drop assume statements" in {
@@ -73,7 +73,7 @@ class VerificationSpec extends AnyFreeSpec with Matchers {
       (output.toString should not).include(
         """printf(clock, and(not(lt(io_in, UInt<8>("h7f"))), UInt<1>("h1")), "input was not less that 0x7f")"""
       )
-      (output.toString should not).include("""stop(clock, and(not(lt(io_in, UInt<8>("h7f"))), UInt<1>("h1")), 66)""")
+      (output.toString should not).include("""stop(_GEN_12, and(not(_GEN_13), _GEN_10), 66)""")
     }
 
     def runStopTest(firrtlString: String): Unit = {


### PR DESCRIPTION
Fix coverage tests view of registers
- Like printf, verification (cover) statements need to use previous values of enable and predicate and arguments
- Add verification statement to AugmentPrintf transform
- For debugging show current value of register (still notes when register was not changed because of clock transition)