### PR TITLE
Update scalafmt sbt plugin

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -7,7 +7,8 @@ assumeStandardLibraryStripMargin = true
 docstrings = ScalaDoc
 lineEndings = preserve
 includeCurlyBraceInSelectChains = false
-danglingParentheses = true
+danglingParentheses.defnSite = true
+danglingParentheses.callSite = true
 
 align.tokens.add = [
   {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,6 @@ logLevel := Level.Warn
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.0.0")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.3")
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.7")
 


### PR DESCRIPTION
Update scalafmt sbt plugin
- 2.42 -> 2.4.3
- change references to danglingParentheses options to stop deprecation-warning