### PR TITLE
TreadleTester: better findTopLevelClocks method

### DIFF
--- a/src/main/scala/treadle/TreadleTester.scala
+++ b/src/main/scala/treadle/TreadleTester.scala
@@ -74,15 +74,8 @@ class TreadleTester(annotationSeq: AnnotationSeq) {
 
   val startTime: Long = System.nanoTime()
 
-  private def findTopLevelClocks() = {
-    engine.symbolTable.symbols.collect {
-      case symbol if symbol.firrtlType == ClockType && !(symbol.name.contains(".") || symbol.name.endsWith("/prev")) =>
-        symbol
-    }.toList
-  }
-
   val clockInfoList: Seq[ClockInfo] = if (clockInfo.isEmpty) {
-    val topClocks = findTopLevelClocks()
+    val topClocks = engine.findTopLevelClocks()
 
     if (topClocks.length > 2) {
       println(s"Warning: multiple top level clocks found without any ClockInfo information, is this intentional?")

--- a/src/main/scala/treadle/executable/ExecutionEngine.scala
+++ b/src/main/scala/treadle/executable/ExecutionEngine.scala
@@ -474,6 +474,11 @@ class ExecutionEngine(
     }
   }
 
+  def findTopLevelClocks(): Seq[Symbol] = {
+    val inputs = symbolTable.symbols.filter(s => symbolTable.isTopLevelInput(s.name))
+    inputs.filter(_.firrtlType == firrtl.ir.ClockType).toList
+  }
+
   /*
   This is where things should go that need to be done at the end of the run.
   Currently this telling black boxes to finish up things if they need to


### PR DESCRIPTION
This avoids many spurious warnings.