### PR TITLE
vcd: exclude all signals that start with `_` by default

### DIFF
--- a/src/main/scala/treadle/vcd/VCD.scala
+++ b/src/main/scala/treadle/vcd/VCD.scala
@@ -563,7 +563,8 @@ case class VCD(
   }
 
   def isTempWire(wireName: String): Boolean = {
-    wireName.split("""\.""").last.startsWith("_T_") || wireName.contains("/")
+    val suffix = wireName.split('.').last
+    suffix.startsWith("_") || wireName.contains("/")
   }
 
   /** Change wire value if it is different that its the last recorded value

--- a/src/test/scala/treadle/vcd/VCDSpec.scala
+++ b/src/test/scala/treadle/vcd/VCDSpec.scala
@@ -216,8 +216,8 @@ class VCDSpec extends AnyFlatSpec with Matchers {
         |    io is invalid
         |    reg testReg : UInt<4>, clock with : (reset => (reset, UInt<1>("h00"))) @[RegisterVCDSpec.scala 30:24]
         |    node _T_6 = add(testReg, UInt<1>("h01")) @[RegisterVCDSpec.scala 31:22]
-        |    node _T_7 = tail(_T_6, 1) @[RegisterVCDSpec.scala 31:22]
-        |    testReg <= _T_7 @[RegisterVCDSpec.scala 31:11]
+        |    node _7 = tail(_T_6, 1) @[RegisterVCDSpec.scala 31:22]
+        |    testReg <= _7 @[RegisterVCDSpec.scala 31:11]
         |    io.testReg <= testReg @[RegisterVCDSpec.scala 32:14]
         |
       """.stripMargin
@@ -259,11 +259,11 @@ class VCDSpec extends AnyFlatSpec with Matchers {
 
     if (hasTempWires) {
       vcd.wires.values.exists { value =>
-        value.name.startsWith("_T_")
+        value.name.startsWith("_")
       } should be(true)
     } else {
       vcd.wires.values.forall { value =>
-        !value.name.startsWith("_T_")
+        !value.name.startsWith("_")
       } should be(true)
     }
   }


### PR DESCRIPTION
This matches the default verilator behavior.