### PR TITLE
Fixes stops hiding other stops

### DIFF
--- a/src/main/scala/treadle/executable/ExpressionCompiler.scala
+++ b/src/main/scala/treadle/executable/ExpressionCompiler.scala
@@ -927,7 +927,7 @@ class ExpressionCompiler(
       case stop @ Stop(info, returnValue, clockExpression, enableExpression) =>
         val stopSymbolName = expand(stop.name)
 
-        symbolTable.stopToStopInfo.get(stop) match {
+        symbolTable.stopToStopInfo.get(stopSymbolName) match {
           case Some(stopInfo) =>
             val intExpression = toIntExpression(enableExpression, s"Error: stop $stop has unknown condition type")
 

--- a/src/main/scala/treadle/executable/ExpressionViewBuilder.scala
+++ b/src/main/scala/treadle/executable/ExpressionViewBuilder.scala
@@ -298,7 +298,8 @@ class ExpressionViewBuilder(
           Memory.buildMemoryExpressions(defMemory, expandedName, scheduler, expressionViews)
         case IsInvalid(info, expression) =>
         case stop @ Stop(info, ret, clockExpression, enableExpression) =>
-          expressionViews(symbolTable.stopToStopInfo(stop).stopSymbol) = processExpression(enableExpression)
+          val stopName = expand(stop.name)
+          expressionViews(symbolTable.stopToStopInfo(stopName).stopSymbol) = processExpression(enableExpression)
 
         case print @ Print(info, stringLiteral, argExpressions, clockExpression, enableExpression) =>
           expressionViews(symbolTable.printToPrintInfo(print).printSymbol) = processExpression(enableExpression)

--- a/src/main/scala/treadle/executable/SymbolTable.scala
+++ b/src/main/scala/treadle/executable/SymbolTable.scala
@@ -49,7 +49,7 @@ class SymbolTable(val nameToSymbol: mutable.HashMap[String, Symbol]) {
 
   val moduleMemoryToMemorySymbol: mutable.HashMap[String, mutable.HashSet[Symbol]] = new mutable.HashMap
 
-  val stopToStopInfo:   mutable.HashMap[Stop, StopInfo] = new mutable.HashMap[Stop, StopInfo]
+  val stopToStopInfo:   mutable.HashMap[String, StopInfo] = new mutable.HashMap[String, StopInfo]
   val printToPrintInfo: mutable.HashMap[Print, PrintInfo] = new mutable.HashMap[Print, PrintInfo]
   val verifyInfo:       mutable.HashMap[String, VerifyInfo] = new mutable.HashMap[String, VerifyInfo]
   val verifyOps:        mutable.ListBuffer[VerifyOp] = new mutable.ListBuffer[VerifyOp]
@@ -190,7 +190,7 @@ object SymbolTable extends LazyLogging {
     val clockSignals = new mutable.HashSet[String]
 
     val registerToClock = new mutable.HashMap[Symbol, Symbol]
-    val stopToStopInfo = new mutable.HashMap[Stop, StopInfo]
+    val stopToStopInfo = new mutable.HashMap[String, StopInfo]
     val instanceNameToModuleName = new mutable.HashMap[String, String]()
     instanceNameToModuleName("") = circuit.main
 
@@ -402,7 +402,7 @@ object SymbolTable extends LazyLogging {
               val stopSymbolName = expand(stop.name)
               val stopSymbol = Symbol(stopSymbolName, IntSize, UnsignedInt, WireKind, 1, 1, UIntType(IntWidth(1)), info)
               addSymbol(stopSymbol)
-              stopToStopInfo(stop) = StopInfo(stopSymbol)
+              stopToStopInfo(stopSymbolName) = StopInfo(stopSymbol)
 
               addDependency(stopSymbol, expressionToReferences(clockExpression))
               addDependency(stopSymbol, expressionToReferences(enableExpression))

--- a/src/test/scala/treadle/StopBehaviorSpec.scala
+++ b/src/test/scala/treadle/StopBehaviorSpec.scala
@@ -238,4 +238,46 @@ class StopBehaviorSpec extends AnyFreeSpec with Matchers {
 
     TreadleTestHarness(Seq(FirrtlSourceAnnotation(input), WriteVcdAnnotation))(multiStopTest("c.", _))
   }
+
+  "stops in the parent and child module should not interfere" in {
+    val input =
+      """circuit MultiStopMultiModuleTest:
+        |  module child:
+        |    input clock: Clock
+        |    input stop0En: UInt<1>
+        |
+        |    stop(clock, stop0En, 0) : stop0
+        |
+        |  module MultiStopMultiModuleTest:
+        |    input clock: Clock
+        |    input stop0En: UInt<1>
+        |    input selParent: UInt<1>
+        |    input selChild0: UInt<1>
+        |
+        |    ; somehow the next two lines make the stop in the child module not fail
+        |    when selParent:
+        |      stop(clock, stop0En, 0) : stop0
+        |
+        |    inst c0 of child
+        |    c0.clock <= clock
+        |    c0.stop0En <= and(selChild0, stop0En)
+        |""".stripMargin
+
+    TreadleTestHarness(Seq(FirrtlSourceAnnotation(input), VerboseAnnotation, WriteVcdAnnotation)) { tester =>
+      // set every input to zero by default
+      tester.poke("stop0En", 0)
+      tester.poke("selParent", 0)
+      tester.poke("selChild0", 0)
+      tester.step()
+
+      tester.poke("selChild0", 1) // we are only testing the child module
+
+      tester.poke("stop0En", 1)
+
+      val e = intercept[StopException] {
+        tester.step()
+      }
+      assert(e.stops.length == 1)
+    }
+  }
 }


### PR DESCRIPTION
Fixes stops hiding other stops
The communication between symbol table assembly and expression compiling used a case class as key
Changed the key to be a string representing the full pathname of the stop.
This seems to fix the problem.