### PR TITLE
Bump to sbt 1.5.6

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.10
+sbt.version=1.5.6


### PR DESCRIPTION
Avoids any possibility of [CVE-2021-44228](https://github.com/advisories/GHSA-jfh8-c2jp-5v3q), although given this is Zinc's own logging, it would be pretty insane to see how that attack vector would manifest here.