### PR TITLE
DataStore: ignore out of bounds writes to memory

### DIFF
--- a/src/main/scala/treadle/executable/DataStore.scala
+++ b/src/main/scala/treadle/executable/DataStore.scala
@@ -291,10 +291,13 @@ class DataStore(val numberOfBuffers: Int, dataStoreAllocator: DataStoreAllocator
     info:           Info)
       extends Assigner {
     val index: Int = memorySymbol.index
+    private val slots = memorySymbol.slots
 
     def runLean(): Unit = {
       if (enable() > 0) {
-        intData(index + (getMemoryIndex.apply() % memorySymbol.slots)) = expression()
+        val memoryIndex = getMemoryIndex.apply()
+        // ignore out of bounds writes
+        if (memoryIndex < slots) { intData(index + memoryIndex) = expression() }
       }
     }
 
@@ -304,9 +307,12 @@ class DataStore(val numberOfBuffers: Int, dataStoreAllocator: DataStoreAllocator
         else { expression() }
 
         val memoryIndex = getMemoryIndex.apply()
-        val previousValue = intData(index + (memoryIndex % memorySymbol.slots))
-        intData(index + (memoryIndex % memorySymbol.slots)) = value
-        runPlugins(memorySymbol, memoryIndex, previousValue)
+        // ignore out of bounds writes
+        if (memoryIndex < slots) {
+          val previousValue = intData(index + memoryIndex)
+          intData(index + memoryIndex) = value
+          runPlugins(memorySymbol, memoryIndex, previousValue)
+        }
       }
     }
 
@@ -325,10 +331,13 @@ class DataStore(val numberOfBuffers: Int, dataStoreAllocator: DataStoreAllocator
     info:           Info)
       extends Assigner {
     val index: Int = memorySymbol.index
+    private val slots = memorySymbol.slots
 
     def runLean(): Unit = {
       if (enable() > 0) {
-        longData(index + (getMemoryIndex.apply() % memorySymbol.slots)) = expression()
+        val memoryIndex = getMemoryIndex.apply()
+        // ignore out of bounds writes
+        if (memoryIndex < slots) { longData(index + memoryIndex) = expression() }
       }
     }
 
@@ -338,9 +347,12 @@ class DataStore(val numberOfBuffers: Int, dataStoreAllocator: DataStoreAllocator
         else { expression() }
 
         val memoryIndex = getMemoryIndex.apply()
-        val previousValue = longData(index + (memoryIndex % memorySymbol.slots))
-        longData(index + (memoryIndex % memorySymbol.slots)) = value
-        runPlugins(memorySymbol, memoryIndex, previousValue)
+        // ignore out of bounds writes
+        if (memoryIndex < slots) {
+          val previousValue = longData(index + memoryIndex)
+          longData(index + memoryIndex) = value
+          runPlugins(memorySymbol, memoryIndex, previousValue)
+        }
       }
     }
 
@@ -359,10 +371,13 @@ class DataStore(val numberOfBuffers: Int, dataStoreAllocator: DataStoreAllocator
     info:           Info)
       extends Assigner {
     val index: Int = memorySymbol.index
+    private val slots = memorySymbol.slots
 
     def runLean(): Unit = {
       if (enable() > 0) {
-        bigData(index + (getMemoryIndex.apply() % memorySymbol.slots)) = expression()
+        val memoryIndex = getMemoryIndex.apply()
+        // ignore out of bounds writes
+        if (memoryIndex < slots) { bigData(index + memoryIndex) = expression() }
       }
     }
 
@@ -372,9 +387,12 @@ class DataStore(val numberOfBuffers: Int, dataStoreAllocator: DataStoreAllocator
         else { expression() }
 
         val memoryIndex = getMemoryIndex.apply()
-        val previousValue = bigData(index + (memoryIndex % memorySymbol.slots))
-        bigData(index + (memoryIndex % memorySymbol.slots)) = value
-        runPlugins(memorySymbol, memoryIndex, previousValue)
+        // ignore out of bounds writes
+        if (memoryIndex < slots) {
+          val previousValue = bigData(index + memoryIndex)
+          bigData(index + memoryIndex) = value
+          runPlugins(memorySymbol, memoryIndex, previousValue)
+        }
       }
     }
 

--- a/src/main/scala/treadle/executable/DataStore.scala
+++ b/src/main/scala/treadle/executable/DataStore.scala
@@ -294,7 +294,7 @@ class DataStore(val numberOfBuffers: Int, dataStoreAllocator: DataStoreAllocator
 
     def runLean(): Unit = {
       if (enable() > 0) {
-        intData(index + getMemoryIndex.apply()) = expression()
+        intData(index + (getMemoryIndex.apply() % memorySymbol.slots)) = expression()
       }
     }
 

--- a/src/test/resources/CircularPointerFifo.lo.fir
+++ b/src/test/resources/CircularPointerFifo.lo.fir
@@ -1,0 +1,54 @@
+circuit CircularPointerFifo :
+  module CircularPointerFifo :
+    input clock : Clock
+    input reset : UInt<1>
+    input io_push : UInt<1>
+    input io_pop : UInt<1>
+    input io_data_in : UInt<8>
+    output io_full : UInt<1>
+    output io_empty : UInt<1>
+    output io_data_out : UInt<8>
+
+    mem entries : @[CircularPointerFifo.scala 38:20]
+      data-type => UInt<8>
+      depth => 5
+      read-latency => 0
+      write-latency => 1
+      reader => input_data_MPORT
+      reader => io_data_out_MPORT
+      writer => MPORT
+      read-under-write => undefined
+    reg cnt : UInt<4>, clock with :
+      reset => (UInt<1>("h0"), cnt) @[CircularPointerFifo.scala 25:20]
+    node _cnt_T = add(cnt, io_push) @[CircularPointerFifo.scala 26:14]
+    node _cnt_T_1 = tail(_cnt_T, 1) @[CircularPointerFifo.scala 26:14]
+    node _cnt_T_2 = sub(_cnt_T_1, io_pop) @[CircularPointerFifo.scala 26:24]
+    node _cnt_T_3 = tail(_cnt_T_2, 1) @[CircularPointerFifo.scala 26:24]
+    reg wrPtr : UInt<3>, clock with :
+      reset => (UInt<1>("h0"), wrPtr) @[CircularPointerFifo.scala 29:22]
+    node _wrPtr_T = add(wrPtr, io_push) @[CircularPointerFifo.scala 30:18]
+    node _wrPtr_T_1 = tail(_wrPtr_T, 1) @[CircularPointerFifo.scala 30:18]
+    reg rdPtr : UInt<3>, clock with :
+      reset => (UInt<1>("h0"), rdPtr) @[CircularPointerFifo.scala 32:22]
+    node _rdPtr_T = add(rdPtr, io_pop) @[CircularPointerFifo.scala 33:18]
+    node _rdPtr_T_1 = tail(_rdPtr_T, 1) @[CircularPointerFifo.scala 33:18]
+    node _io_empty_T = eq(cnt, UInt<1>("h0")) @[CircularPointerFifo.scala 35:19]
+    node _io_full_T = eq(cnt, UInt<3>("h5")) @[CircularPointerFifo.scala 36:18]
+    node input_data = mux(io_push, io_data_in, entries.input_data_MPORT.data) @[CircularPointerFifo.scala 39:23]
+    io_full <= _io_full_T @[CircularPointerFifo.scala 36:11]
+    io_empty <= _io_empty_T @[CircularPointerFifo.scala 35:12]
+    io_data_out <= entries.io_data_out_MPORT.data @[CircularPointerFifo.scala 43:17]
+    cnt <= mux(reset, UInt<4>("h0"), _cnt_T_3) @[CircularPointerFifo.scala 25:{20,20} 26:7]
+    wrPtr <= mux(reset, UInt<3>("h0"), _wrPtr_T_1) @[CircularPointerFifo.scala 29:{22,22} 30:9]
+    rdPtr <= mux(reset, UInt<3>("h0"), _rdPtr_T_1) @[CircularPointerFifo.scala 32:{22,22} 33:9]
+    entries.input_data_MPORT.addr <= wrPtr @[CircularPointerFifo.scala 39:57]
+    entries.input_data_MPORT.en <= UInt<1>("h1") @[CircularPointerFifo.scala 39:57]
+    entries.input_data_MPORT.clk <= clock @[CircularPointerFifo.scala 39:57]
+    entries.io_data_out_MPORT.addr <= rdPtr @[CircularPointerFifo.scala 43:32]
+    entries.io_data_out_MPORT.en <= UInt<1>("h1") @[CircularPointerFifo.scala 43:32]
+    entries.io_data_out_MPORT.clk <= clock @[CircularPointerFifo.scala 43:32]
+    entries.MPORT.addr <= wrPtr
+    entries.MPORT.en <= UInt<1>("h1")
+    entries.MPORT.clk <= clock
+    entries.MPORT.data <= input_data
+    entries.MPORT.mask <= UInt<1>("h1")


### PR DESCRIPTION
This seems to be a copy-paste error. The `Long` and `BigInt` versions already correctly implemented the wrapping.